### PR TITLE
Fix issues with Entra data not being available after the Setup Wizard completes

### DIFF
--- a/Intuneomator/AppDataManager.swift
+++ b/Intuneomator/AppDataManager.swift
@@ -302,6 +302,32 @@ class AppDataManager {
         }
     }
     
+    /// Reinitializes the AppDataManager after authentication configuration changes.
+    /// 
+    /// Clears all cached data and attempts to fetch fresh data from APIs. This method
+    /// is specifically designed for scenarios where authentication has been newly
+    /// configured (such as after completing the setup wizard) and the data that
+    /// previously failed to load should be retried.
+    /// 
+    /// - Throws: `AppDataManagerError` if any of the fetch operations fail
+    /// 
+    /// **Use Cases:**
+    /// - After completing the setup wizard
+    /// - After updating authentication credentials
+    /// - When switching between different Intune tenants
+    /// - After resolving authentication issues
+    func reinitializeAfterAuthSetup() async throws {
+        Logger.info("Reinitializing AppDataManager after authentication setup...", category: .core, toUserDirectory: true)
+        
+        // Clear any stale cached data first
+        clearAllData()
+        
+        // Fetch fresh data with newly configured authentication
+        try await refreshAllData()
+        
+        Logger.info("AppDataManager reinitialization completed successfully", category: .core, toUserDirectory: true)
+    }
+    
     /// Clears all cached data and resets freshness timestamps.
     /// 
     /// Removes all cached data and resets internal state. Useful when switching

--- a/Intuneomator/EntraIDWizard/WelcomeWizardViewController.swift
+++ b/Intuneomator/EntraIDWizard/WelcomeWizardViewController.swift
@@ -183,6 +183,7 @@ class WelcomeWizardViewController: NSViewController, NSTableViewDelegate, NSTabl
     
     /// Instantiates and displays the main application window after wizard completion
     /// Lazy-loads the main window controller from storyboard if not already created
+    /// Also triggers AppDataManager initialization since auth is now configured
     func showMainWindow() {
         // Create main window controller if not already instantiated
         if mainWindowController == nil {
@@ -194,8 +195,23 @@ class WelcomeWizardViewController: NSViewController, NSTableViewDelegate, NSTabl
         if let window = mainWindowController?.window {
             window.delegate = mainWindowController // Ensure delegate is properly set
             window.makeKeyAndOrderFront(nil)
+            
+            // Initialize AppDataManager now that authentication is configured
+            Task {
+                await loadInitialDataAfterSetup()
+            }
         } else {
             Logger.info("Error: mainWindowController has no window.", category: .core, toUserDirectory: true)
+        }
+    }
+    
+    /// Loads initial application data after wizard completion
+    /// Fetches essential data from Microsoft Graph API that was skipped during first run
+    private func loadInitialDataAfterSetup() async {
+        do {
+            try await AppDataManager.shared.reinitializeAfterAuthSetup()
+        } catch {
+            Logger.error("Error reinitializing AppDataManager after setup: \(error.localizedDescription)", category: .core, toUserDirectory: true)
         }
     }
 


### PR DESCRIPTION
Fix issues with Entra data not being available after the Setup Wizard completes.

  New First Run Flow:
    - App starts → Authentication not configured → AppDataManager skips data loading
    - Setup wizard runs → User configures Entra ID authentication
    - Setup completes → showMainWindow() called
    - Main window appears → loadInitialDataAfterSetup() runs in background
    - AppDataManager reinitializes and fetches Groups, Filters, Categories
    - App is fully functional without restart


This PR address this issue:
https://github.com/gilburns/Intuneomator/issues/2