### PR TITLE
Fix for Full group list not loading

### DIFF
--- a/Intuneomator/Base.lproj/Main.storyboard
+++ b/Intuneomator/Base.lproj/Main.storyboard
@@ -3832,16 +3832,16 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <box title="Virtual Groups:" translatesAutoresizingMaskIntoConstraints="NO" id="cz8-lp-vOX">
-                                <rect key="frame" x="17" y="397" width="338" height="89"/>
+                                <rect key="frame" x="17" y="313" width="378" height="173"/>
                                 <view key="contentView" id="mfP-yc-Glp">
-                                    <rect key="frame" x="4" y="5" width="330" height="69"/>
+                                    <rect key="frame" x="4" y="5" width="370" height="153"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="50" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dAD-Kg-XUg">
-                                            <rect key="frame" x="41" y="30" width="248" height="19"/>
+                                            <rect key="frame" x="61" y="30" width="248" height="103"/>
                                             <subviews>
                                                 <button toolTip="All Devices is not an option for Available intent" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b9J-ne-wCE">
-                                                    <rect key="frame" x="-3" y="-1.5" width="109" height="22"/>
+                                                    <rect key="frame" x="-3" y="40.5" width="109" height="22"/>
                                                     <buttonCell key="cell" type="check" title="All Devices" bezelStyle="regularSquare" imagePosition="left" controlSize="large" inset="2" id="vQv-u0-Uec">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system" size="16"/>
@@ -3851,7 +3851,7 @@ Gw
                                                     </connections>
                                                 </button>
                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="q98-Vt-pfT" userLabel="All Users">
-                                                    <rect key="frame" x="153" y="-1.5" width="95" height="22"/>
+                                                    <rect key="frame" x="153" y="40.5" width="95" height="22"/>
                                                     <buttonCell key="cell" type="check" title="All Users" bezelStyle="regularSquare" imagePosition="left" controlSize="large" inset="2" id="ugl-NM-K2O">
                                                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                         <font key="font" metaFont="system" size="16"/>
@@ -3882,7 +3882,7 @@ Gw
                                 </view>
                             </box>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="msq-sl-sc6">
-                                <rect key="frame" x="18" y="494" width="336" height="16"/>
+                                <rect key="frame" x="18" y="494" width="376" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="Add Assignment" id="uL3-8V-U4t">
                                     <font key="font" usesAppearanceFont="YES"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -3896,13 +3896,13 @@ Gw
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <scrollView autohidesScrollers="YES" horizontalLineScroll="17" horizontalPageScroll="10" verticalLineScroll="17" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jfm-pY-6rB">
-                                            <rect key="frame" x="20" y="27" width="310" height="250"/>
+                                            <rect key="frame" x="20" y="27" width="330" height="166"/>
                                             <clipView key="contentView" id="qZF-J9-ywd">
-                                                <rect key="frame" x="1" y="1" width="308" height="248"/>
+                                                <rect key="frame" x="1" y="1" width="328" height="164"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowSizeStyle="automatic" headerView="4sa-Gq-N1J" viewBased="YES" id="ikr-2H-C7L">
-                                                        <rect key="frame" x="0.0" y="0.0" width="466" height="220"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="466" height="136"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="17" height="0.0"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -4009,7 +4009,7 @@ Gw
                                                 </subviews>
                                             </clipView>
                                             <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Fha-0b-bPh">
-                                                <rect key="frame" x="1" y="233" width="308" height="16"/>
+                                                <rect key="frame" x="1" y="149" width="328" height="16"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="pOP-XB-KaX">
@@ -4047,7 +4047,7 @@ DQ
                                 </connections>
                             </button>
                             <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qU7-5V-dOM">
-                                <rect key="frame" x="147" y="366" width="205" height="19"/>
+                                <rect key="frame" x="187" y="282" width="205" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="205" id="Bvu-ZM-lTq"/>
                                 </constraints>
@@ -4070,7 +4070,7 @@ DQ
                             </textField>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bZb-Op-cfn">
                                 <rect key="frame" x="13" y="13" width="85" height="32"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="push" title="Clear All" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ik0-i5-B0L">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -4095,6 +4095,15 @@ Gw
                                     <action selector="dismissController:" target="ZqH-tu-tlB" id="TLt-Su-bhF"/>
                                 </connections>
                             </button>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yc1-Tv-RRi">
+                                <rect key="frame" x="128" y="367" width="145" height="14"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" alignment="right" title="X of X" id="Nge-P5-2mJ">
+                                    <font key="font" metaFont="smallSystem"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="UBX-Pz-Irr" secondAttribute="bottom" constant="20" symbolic="YES" id="6V3-FZ-Rvh"/>
@@ -4123,6 +4132,7 @@ Gw
                         <outlet property="allUsersButton" destination="q98-Vt-pfT" id="XPD-fc-hEP"/>
                         <outlet property="clearAllButton" destination="bZb-Op-cfn" id="hXA-c1-aVH"/>
                         <outlet property="groupAssignTitleField" destination="msq-sl-sc6" id="8SN-VQ-vWr"/>
+                        <outlet property="groupCountLabel" destination="Yc1-Tv-RRi" id="Rq5-FF-eqC"/>
                         <outlet property="saveButton" destination="SI8-BT-OlN" id="IKP-0f-T4a"/>
                         <outlet property="searchField" destination="qU7-5V-dOM" id="u5I-JB-dEv"/>
                         <outlet property="tableView" destination="ikr-2H-C7L" id="iTi-iU-EUd"/>

--- a/Intuneomator/ViewControllers/GroupSelectViewController.swift
+++ b/Intuneomator/ViewControllers/GroupSelectViewController.swift
@@ -44,6 +44,8 @@ class GroupSelectViewController: NSViewController, NSTableViewDelegate, NSTableV
     @IBOutlet weak var searchField: NSSearchField!
     
     @IBOutlet weak var clearAllButton: NSButton!
+    
+    @IBOutlet weak var groupCountLabel: NSTextField!
 
     
     // Input data
@@ -114,6 +116,7 @@ class GroupSelectViewController: NSViewController, NSTableViewDelegate, NSTableV
         
         // Reload the table view
         DispatchQueue.main.async {
+            self.setGroupCountLabel()
             self.tableView.reloadData()
             self.updateVirtualCheckboxState()
         }
@@ -164,7 +167,7 @@ class GroupSelectViewController: NSViewController, NSTableViewDelegate, NSTableV
         // Enable/disable based on assignment type restrictions and exclusions
         allDevicesButton.isEnabled = allDevicesAvailable && !allDevicesExcluded
         allUsersButton.isEnabled = !allUsersExcluded
-        
+                
         // Reload the table to update all checkboxes
         tableView.reloadData()
     }
@@ -188,9 +191,15 @@ class GroupSelectViewController: NSViewController, NSTableViewDelegate, NSTableV
             }
         }
         
+        setGroupCountLabel()
         tableView.reloadData()
     }
     
+    func setGroupCountLabel() {
+        let filteredGroupsCount = filteredGroups.count
+        let allGroupsCount = allGroups.count
+        groupCountLabel.stringValue = String(format: "%d of %d", filteredGroupsCount, allGroupsCount)
+    }
     
     // MARK: - Actions
     // IBAction for the Save button to gather the selections and pass them back via the delegate:

--- a/Intuneomator/XPCManager/XPCManager+GraphAPI.swift
+++ b/Intuneomator/XPCManager/XPCManager+GraphAPI.swift
@@ -28,6 +28,26 @@ extension XPCManager {
         sendRequest({ $0.fetchEntraGroups(reply: $1) }, completion: completion)
     }
     
+    /// Searches for security-enabled groups by name using startswith filtering
+    /// More efficient than loading all groups for large environments with 1000+ groups
+    /// - Parameters:
+    ///   - searchQuery: Text to search for in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - completion: Callback with array of matching group dictionaries or nil on failure
+    func searchEntraGroups(searchQuery: String, maxResults: Int = 50, completion: @escaping ([[String: Any]]?) -> Void) {
+        sendRequest({ $0.searchEntraGroups(searchQuery: searchQuery, maxResults: maxResults, reply: $1) }, completion: completion)
+    }
+    
+    /// Searches for security-enabled groups by name using contains filtering for broader matching
+    /// Alternative search method when startswith doesn't return enough results
+    /// - Parameters:
+    ///   - searchQuery: Text to search for anywhere in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - completion: Callback with array of matching group dictionaries or nil on failure
+    func searchEntraGroupsContains(searchQuery: String, maxResults: Int = 50, completion: @escaping ([[String: Any]]?) -> Void) {
+        sendRequest({ $0.searchEntraGroupsContains(searchQuery: searchQuery, maxResults: maxResults, reply: $1) }, completion: completion)
+    }
+    
     /// Retrieves macOS-specific assignment filters from Microsoft Intune
     /// Filters enable conditional assignment based on device properties and attributes
     /// - Parameter completion: Callback with array of filter dictionaries or nil on failure

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Groups.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Groups.swift
@@ -15,13 +15,91 @@ extension EntraGraphRequests {
     
     // MARK: - Security Groups Retrieval
     
-    /// Fetches all security-enabled groups from Microsoft Graph with filtering and sorting
+    /// Fetches all security-enabled groups from Microsoft Graph with pagination support
     /// Used to retrieve groups available for Intune application assignments
+    /// Handles pagination to ensure all groups are fetched from large environments (1000+ groups)
     /// - Parameter authToken: OAuth bearer token for Microsoft Graph authentication
     /// - Returns: Array of dictionaries containing security group information, sorted by display name
     /// - Throws: Network errors, authentication errors, or JSON parsing errors
     static func fetchEntraGroups(authToken: String) async throws -> [[String: Any]] {
-        let url = URL(string: "https://graph.microsoft.com/v1.0/groups?$filter=securityEnabled eq true&$select=id,description,displayName,securityEnabled")!
+        var allGroups: [[String: Any]] = []
+        var nextPageUrl: String? = "https://graph.microsoft.com/v1.0/groups?$filter=securityEnabled eq true&$select=id,description,displayName,securityEnabled"
+        var pageCount = 0
+        
+        Logger.info("Starting paginated fetch of Entra groups...", category: .core)
+        
+        // Follow pagination until all groups are fetched
+        while let urlString = nextPageUrl {
+            guard let url = URL(string: urlString) else {
+                throw NSError(domain: "AppDataManager", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid pagination URL: \(urlString)"])
+            }
+            
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+            
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                throw NSError(domain: "AppDataManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch Entra groups (page \(pageCount + 1))"])
+            }
+            
+            // Parse JSON response
+            guard let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+                throw NSError(domain: "AppDataManager", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON response format for Entra groups (page \(pageCount + 1))"])
+            }
+            
+            // Extract groups from this page
+            guard let pageGroups = json["value"] as? [[String: Any]] else {
+                throw NSError(domain: "AppDataManager", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid response format for Entra groups (page \(pageCount + 1))"])
+            }
+            
+            allGroups.append(contentsOf: pageGroups)
+            pageCount += 1
+            
+            // Check for next page
+            nextPageUrl = json["@odata.nextLink"] as? String
+            
+            Logger.info("Fetched page \(pageCount) with \(pageGroups.count) groups (total: \(allGroups.count))", category: .core)
+            
+            // Safety check to prevent infinite loops
+            if pageCount > 100 {
+                Logger.error("Safety limit reached: stopping after 100 pages of groups", category: .core)
+                break
+            }
+        }
+        
+        Logger.info("Completed fetching \(allGroups.count) total groups across \(pageCount) pages", category: .core)
+        
+        // Sort all groups alphabetically by display name
+        return allGroups.sorted {
+            guard let name1 = $0["displayName"] as? String, let name2 = $1["displayName"] as? String else { return false }
+            return name1.localizedCaseInsensitiveCompare(name2) == .orderedAscending
+        }
+    }
+
+    // MARK: - Alternative: Just-in-Time Group Search (Recommended for Large Environments)
+    
+    /// Searches for security-enabled groups by name with real-time filtering
+    /// More efficient than loading all groups for large environments (1000+ groups)
+    /// - Parameters:
+    ///   - authToken: OAuth bearer token for Microsoft Graph authentication
+    ///   - searchQuery: Text to search for in group display names (case-insensitive)
+    ///   - maxResults: Maximum number of results to return (default: 50)
+    /// - Returns: Array of matching groups, sorted by display name
+    /// - Throws: Network errors, authentication errors, or JSON parsing errors
+    static func searchEntraGroups(authToken: String, searchQuery: String, maxResults: Int = 50) async throws -> [[String: Any]] {
+        // URL encode the search query
+        let encodedQuery = searchQuery.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        
+        // Use startswith for better performance than contains
+        let filterQuery = "securityEnabled eq true and startswith(displayName,'\(encodedQuery)')"
+        let encodedFilter = filterQuery.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        
+        let urlString = "https://graph.microsoft.com/v1.0/groups?$filter=\(encodedFilter)&$select=id,description,displayName,securityEnabled&$top=\(maxResults)&$orderby=displayName"
+        
+        guard let url = URL(string: urlString) else {
+            throw NSError(domain: "AppDataManager", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid search URL"])
+        }
         
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
@@ -29,18 +107,56 @@ extension EntraGraphRequests {
         
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
-            throw NSError(domain: "AppDataManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch Entra groups"])
+            throw NSError(domain: "AppDataManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to search Entra groups"])
         }
         
-        // Parse JSON response and sort groups alphabetically by display name
+        // Parse JSON response
         if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
            let values = json["value"] as? [[String: Any]] {
-            return values.sorted {
-                guard let name1 = $0["displayName"] as? String, let name2 = $1["displayName"] as? String else { return false }
-                return name1.localizedCaseInsensitiveCompare(name2) == .orderedAscending
-            }
+            Logger.info("Group search for '\(searchQuery)' returned \(values.count) results", category: .core)
+            return values
         }
-        throw NSError(domain: "AppDataManager", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid response format for Entra groups"])
+        
+        throw NSError(domain: "AppDataManager", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid response format for group search"])
+    }
+    
+    /// Searches for security-enabled groups with "contains" logic for broader matching
+    /// Alternative search method when startswith doesn't return enough results
+    /// - Parameters:
+    ///   - authToken: OAuth bearer token for Microsoft Graph authentication
+    ///   - searchQuery: Text to search for anywhere in group display names
+    ///   - maxResults: Maximum number of results to return (default: 50)
+    /// - Returns: Array of matching groups, sorted by display name
+    /// - Throws: Network errors, authentication errors, or JSON parsing errors
+    static func searchEntraGroupsContains(authToken: String, searchQuery: String, maxResults: Int = 50) async throws -> [[String: Any]] {
+        let encodedQuery = searchQuery.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        
+        // Use contains for broader matching (less performant but more comprehensive)
+        let filterQuery = "securityEnabled eq true and contains(displayName,'\(encodedQuery)')"
+        let encodedFilter = filterQuery.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        
+        let urlString = "https://graph.microsoft.com/v1.0/groups?$filter=\(encodedFilter)&$select=id,description,displayName,securityEnabled&$top=\(maxResults)&$orderby=displayName"
+        
+        guard let url = URL(string: urlString) else {
+            throw NSError(domain: "AppDataManager", code: 3, userInfo: [NSLocalizedDescriptionKey: "Invalid search URL"])
+        }
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw NSError(domain: "AppDataManager", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to search Entra groups"])
+        }
+        
+        if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+           let values = json["value"] as? [[String: Any]] {
+            Logger.info("Group search (contains) for '\(searchQuery)' returned \(values.count) results", category: .core)
+            return values
+        }
+        
+        throw NSError(domain: "AppDataManager", code: 2, userInfo: [NSLocalizedDescriptionKey: "Invalid response format for group search"])
     }
 
     // MARK: - Group Lookup Operations

--- a/IntuneomatorService/XPCService/XPCService+GraphAPI.swift
+++ b/IntuneomatorService/XPCService/XPCService+GraphAPI.swift
@@ -48,6 +48,46 @@ extension XPCService {
         }
     }
     
+    /// Searches for security-enabled groups by name using startswith filtering
+    /// More efficient than loading all groups for large environments with 1000+ groups
+    /// - Parameters:
+    ///   - searchQuery: Text to search for in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - reply: Callback with array of matching group dictionaries or nil on failure
+    func searchEntraGroups(searchQuery: String, maxResults: Int, reply: @escaping ([[String : Any]]?) -> Void) {
+        Task {
+            do {
+                let entraAuthenticator = EntraAuthenticator.shared
+                let authToken = try await entraAuthenticator.getEntraIDToken()
+                let groups = try await EntraGraphRequests.searchEntraGroups(authToken: authToken, searchQuery: searchQuery, maxResults: maxResults)
+                reply(groups)
+            } catch {
+                Logger.error("Failed to search Entra groups (startswith): \(error.localizedDescription)", category: .core)
+                reply(nil)
+            }
+        }
+    }
+    
+    /// Searches for security-enabled groups by name using contains filtering for broader matching
+    /// Alternative search method when startswith doesn't return enough results
+    /// - Parameters:
+    ///   - searchQuery: Text to search for anywhere in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - reply: Callback with array of matching group dictionaries or nil on failure
+    func searchEntraGroupsContains(searchQuery: String, maxResults: Int, reply: @escaping ([[String : Any]]?) -> Void) {
+        Task {
+            do {
+                let entraAuthenticator = EntraAuthenticator.shared
+                let authToken = try await entraAuthenticator.getEntraIDToken()
+                let groups = try await EntraGraphRequests.searchEntraGroupsContains(authToken: authToken, searchQuery: searchQuery, maxResults: maxResults)
+                reply(groups)
+            } catch {
+                Logger.error("Failed to search Entra groups (contains): \(error.localizedDescription)", category: .core)
+                reply(nil)
+            }
+        }
+    }
+    
     /// Retrieves macOS-specific assignment filters from Microsoft Intune
     /// Filters enable conditional assignment based on device properties and attributes
     /// - Parameter reply: Callback with array of filter dictionaries or nil on failure

--- a/SharedCode/XPCServiceProtocol.swift
+++ b/SharedCode/XPCServiceProtocol.swift
@@ -255,6 +255,20 @@ import Foundation
     /// - Parameter reply: Callback with array of group dictionaries or nil on error
     func fetchEntraGroups(reply: @escaping ([[String: Any]]?) -> Void)
     
+    /// Searches Azure AD groups by name with startswith filtering
+    /// - Parameters:
+    ///   - searchQuery: Text to search for in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - reply: Callback with array of matching group dictionaries or nil on error
+    func searchEntraGroups(searchQuery: String, maxResults: Int, reply: @escaping ([[String: Any]]?) -> Void)
+    
+    /// Searches Azure AD groups by name with contains filtering for broader matching
+    /// - Parameters:
+    ///   - searchQuery: Text to search for anywhere in group display names
+    ///   - maxResults: Maximum number of results to return
+    ///   - reply: Callback with array of matching group dictionaries or nil on error
+    func searchEntraGroupsContains(searchQuery: String, maxResults: Int, reply: @escaping ([[String: Any]]?) -> Void)
+    
     /// Fetches macOS assignment filters from Microsoft Graph
     /// - Parameter reply: Callback with array of filter dictionaries or nil on error
     func fetchAssignmentFiltersForMac(reply: @escaping ([[String: Any]]?) -> Void)


### PR DESCRIPTION
  Implementation Summary

  Enhanced fetchEntraGroups:
  - Full pagination using @odata.nextLink until all groups are fetched
  - Comprehensive logging

  New Just-in-Time Search Functions:
  - searchEntraGroups() - Efficient "startswith" filtering
  - searchEntraGroupsContains() - Broader "contains" matching
  - Both support configurable result limits (default: 50)
  - Will add access to this in the GUI at a later time

  Complete XPC Interface:
  - Added methods to XPCServiceProtocol.swift
  - Implemented in XPCService+GraphAPI.swift
  - Client access via XPCManager+GraphAPI.swift

  Enhancements to GUI app GroupSelectViewController panel:
  - Added filtered count
  - Added total group count

This changes address this issue:
https://github.com/gilburns/Intuneomator/issues/3