### PR TITLE
Added ability to do update checking live in the app instead of only on scheduled daemon

### DIFF
--- a/Intuneomator/MainViewController+Actions.swift
+++ b/Intuneomator/MainViewController+Actions.swift
@@ -446,7 +446,8 @@ extension MainViewController {
                 self.statusLabel.stringValue = "Triggering automation for \(readyCount) ready labels..."
                 Logger.info("User confirmed automation trigger for \(readyCount) labels", category: .core, toUserDirectory: true)
                 
-                XPCManager.shared.triggerFullAutomation { [weak self] result in
+
+                XPCManager.shared.triggerDaemon(triggerType: "automation") { [weak self] result in
                     DispatchQueue.main.async {
                         guard let self = self else { return }
                         

--- a/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
+++ b/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
@@ -198,21 +198,23 @@ extension XPCManager {
     
     // MARK: - Automation Trigger
     
-    /// Triggers full automation for all managed labels
-    /// Creates trigger file for Launch Daemon to process all labels in queue
-    /// - Parameter completion: Callback with success status and optional message, or nil on XPC failure
-    func triggerFullAutomation(completion: @escaping ((Bool, String?)?) -> Void) {
+    /// Triggers daemon for specific types
+    /// Creates trigger files for Launch Daemons to process various operations
+    /// - Parameters:
+    ///   - triggerType: Type of trigger ("automation", "updatecheck", "cachecleaner", "labelupdater")
+    ///   - completion: Callback with success status and optional message, or nil on XPC failure
+    func triggerDaemon(triggerType: String, completion: @escaping ((Bool, String?)?) -> Void) {
         // Custom implementation since sendRequest doesn't support tuple return types
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             guard let service = self?.connection?.remoteObjectProxyWithErrorHandler({ error in
-                Logger.info("XPCManager: XPC connection error during automation trigger: \(error)", category: .core, toUserDirectory: true)
+                Logger.info("XPCManager: XPC connection error during \(triggerType) trigger: \(error)", category: .core, toUserDirectory: true)
                 completion(nil)
             }) as? XPCServiceProtocol else {
                 completion(nil)
                 return
             }
             
-            service.triggerAutomation { success, message in
+            service.triggerDaemon(triggerType: triggerType) { success, message in
                 completion((success, message))
             }
         }

--- a/SharedCode/XPCServiceProtocol.swift
+++ b/SharedCode/XPCServiceProtocol.swift
@@ -391,9 +391,11 @@ import Foundation
     
     // MARK: - Automation Trigger
     
-    /// Triggers automation by creating the trigger file
-    /// - Parameter reply: Callback with success status and optional message
-    func triggerAutomation(reply: @escaping (Bool, String?) -> Void)
+    /// Triggers daemon by creating the appropriate trigger file for Launch Daemon processing
+    /// - Parameters:
+    ///   - triggerType: Type of trigger to create ("automation", "updatecheck", "cachecleaner", "labelupdater")
+    ///   - reply: Callback with success status and optional message
+    func triggerDaemon(triggerType: String, reply: @escaping (Bool, String?) -> Void)
     
     /// Checks if automation is currently running by examining the status file
     /// - Parameter reply: Callback indicating if automation is active


### PR DESCRIPTION
- Updated the triggerAutomation to be triggerDaemon and accept a string argument to allow it to work with other daemons
- Updated associated XPCService/XPCManager files for same
- Added checkForUpdatesFromMenu to AppDelegate to trigger immediate update checks
- Helper methods to handle immediate updates or direct user to releases page