### PR TITLE
Teams notifications update

### DIFF
--- a/Intuneomator/Settings/Settings.storyboard
+++ b/Intuneomator/Settings/Settings.storyboard
@@ -269,6 +269,17 @@
                                                 <action selector="notificationStyleChanged:" target="notifications-settings-vc" id="5t9-cg-M4H"/>
                                             </connections>
                                         </popUpButton>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ukW-qd-p3S">
+                                            <rect key="frame" x="459" y="238" width="81" height="16"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="push" title="Test Webhook" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="rXU-Md-F1W">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="miniSystem"/>
+                                                <connections>
+                                                    <action selector="testTeamsWebhook:" target="notifications-settings-vc" id="w7c-Pv-g3U"/>
+                                                </connections>
+                                            </buttonCell>
+                                        </button>
                                     </subviews>
                                 </view>
                             </box>
@@ -282,6 +293,7 @@
                         <outlet property="buttonSendTeamsNotificationsForLabelUpdates" destination="uKU-6j-jie" id="Tic-6J-dpQ"/>
                         <outlet property="buttonSendTeamsNotificationsForUpdates" destination="90K-W3-1am" id="mIA-kH-ljd"/>
                         <outlet property="buttonSendTeamsNotificationsStyle" destination="k3y-bz-kcJ" id="Bkr-VD-HZH"/>
+                        <outlet property="buttonTestTeamsWebhook" destination="ukW-qd-p3S" id="R94-Kt-5bR"/>
                         <outlet property="fieldTeamsWebhookURL" destination="lsc-76-gqp" id="ghC-P5-19g"/>
                     </connections>
                 </viewController>
@@ -483,7 +495,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="name" id="lBX-qx-ALB">
-                                                            <rect key="frame" x="18" y="0.0" width="178" height="24"/>
+                                                            <rect key="frame" x="8" y="0.0" width="178" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="onM-au-wRa">
@@ -515,7 +527,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="account" id="7Lx-jA-2zQ">
-                                                            <rect key="frame" x="213" y="0.0" width="150" height="24"/>
+                                                            <rect key="frame" x="203" y="0.0" width="150" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ih5-n0-o5v">
@@ -547,7 +559,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="container" id="iwC-xw-2CH">
-                                                            <rect key="frame" x="380" y="0.0" width="100" height="24"/>
+                                                            <rect key="frame" x="370" y="0.0" width="100" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hea-Cs-IM4">
@@ -579,7 +591,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="auth" id="8XH-QN-TcS">
-                                                            <rect key="frame" x="497" y="0.0" width="140" height="24"/>
+                                                            <rect key="frame" x="487" y="0.0" width="140" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kkq-un-7MS">
@@ -611,7 +623,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="cleanup" id="HUJ-MV-8d7">
-                                                            <rect key="frame" x="654" y="0.0" width="70" height="24"/>
+                                                            <rect key="frame" x="644" y="0.0" width="70" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="y3i-di-vTS">
@@ -643,7 +655,7 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView identifier="status" id="JFs-tj-HH3">
-                                                            <rect key="frame" x="741" y="0.0" width="72" height="24"/>
+                                                            <rect key="frame" x="731" y="0.0" width="72" height="24"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yDX-OI-dqF">

--- a/Intuneomator/XPCManager/XPCManager+Settings.swift
+++ b/Intuneomator/XPCManager/XPCManager+Settings.swift
@@ -259,6 +259,22 @@ extension XPCManager {
         sendRequest({ $0.getTeamsNotificationsStyle(reply: $1) }, completion: completion)
     }
 
+    /// Sends a test notification to verify Teams webhook configuration
+    /// Sends a formatted test message to the configured Teams channel to confirm connectivity
+    /// - Parameter completion: Callback with success status or nil on XPC failure
+    func sendTeamsTestNotification(completion: @escaping (Bool?) -> Void) {
+        sendRequest({ $0.sendTeamsTestNotification(reply: $1) }, completion: completion)
+    }
+
+    /// Sends a test notification to a specific webhook URL without saving it
+    /// Allows testing webhook URLs before committing them to configuration
+    /// - Parameters:
+    ///   - webhookURL: The webhook URL to test
+    ///   - completion: Callback with success status or nil on XPC failure
+    func sendTeamsTestNotification(withURL webhookURL: String, completion: @escaping (Bool?) -> Void) {
+        sendRequest({ $0.sendTeamsTestNotificationWithURL(webhookURL: webhookURL, reply: $1) }, completion: completion)
+    }
+
     /// Retrieves the SHA-1 thumbprint of the stored authentication certificate
     /// Used for certificate identification and validation
     /// - Parameter completion: Callback with certificate thumbprint string or nil on XPC failure

--- a/IntuneomatorService/TeamsNotifier/TeamsNotifier+NotifyTest.swift
+++ b/IntuneomatorService/TeamsNotifier/TeamsNotifier+NotifyTest.swift
@@ -1,0 +1,161 @@
+//
+//  TeamsNotifier+NotifyTest.swift
+//  Intuneomator
+//
+//  Created by Gil Burns on 10/11/25.
+//
+
+import Foundation
+
+// MARK: - Test Notification Extension
+
+/// Extension for sending a test notification to Microsoft Teams
+/// Provides a simple way to verify Teams webhook configuration is working correctly
+extension TeamsNotifier {
+
+    /// Sends a test notification to Microsoft Teams to verify webhook connectivity
+    /// Creates a simple adaptive card with test message and timestamp
+    /// - Returns: True if the test notification was sent successfully, false otherwise
+    func sendTestNotification() async -> Bool {
+        // Configure notification branding and metadata
+        let title = "🧪 Test Notification"
+        let intuneomatorIconUrl = "https://icons.intuneomator.org/intuneomator.png"
+        let time = "🕰️ \(TeamsNotifier.dateFormatter.string(from: Date()))"
+
+        // Build adaptive card body content for test message
+        let bodyContent: [[String: Any]] = [
+            // Header row with icon and test indicator
+            [
+                "type": "ColumnSet",
+                "columns": [
+                    [
+                        "type": "Column",
+                        "items": [
+                            ["type": "Image", "url": intuneomatorIconUrl, "size": "Medium"]
+                        ],
+                        "width": "auto"
+                    ],
+                    [
+                        "type": "Column",
+                        "items": [
+                            ["type": "TextBlock", "text": " ", "weight": "Bolder", "size": "Medium"]
+                        ],
+                        "width": "stretch"
+                    ],
+                    [
+                        "type": "Column",
+                        "items": [
+                            [
+                                "type": "FactSet",
+                                "facts": [
+                                    [
+                                        "title": " ",
+                                        "value": "🟢 **TEST**",
+                                        "color": "Good"
+                                    ]
+                                ]
+                            ]
+                        ],
+                        "width": "auto",
+                        "style": "good"
+                    ]
+                ]
+            ],
+            // Main title
+            [
+                "type": "TextBlock",
+                "text": "**\(title)**",
+                "weight": "Bolder",
+                "spacing": "None",
+                "size": "Large"
+            ],
+            // Test description
+            [
+                "type": "TextBlock",
+                "text": "This is a test notification from Intuneomator",
+                "weight": "Lighter",
+                "spacing": "Small",
+                "size": "Small"
+            ],
+            // Timestamp
+            [
+                "type": "TextBlock",
+                "text": "\(time)",
+                "weight": "Lighter",
+                "spacing": "Small",
+                "size": "Small"
+            ],
+            // Section separator
+            [
+                "type": "TextBlock",
+                "text": "---",
+                "weight": "Lighter",
+                "spacing": "Medium",
+                "separator": true
+            ],
+            // Test message body
+            [
+                "type": "TextBlock",
+                "text": "✅ Your Teams webhook is configured correctly and notifications are working!",
+                "wrap": true,
+                "spacing": "Medium"
+            ],
+            // Additional info
+            [
+                "type": "TextBlock",
+                "text": "If you received this message, Intuneomator can successfully send notifications to your Microsoft Teams channel.",
+                "wrap": true,
+                "spacing": "Small",
+                "size": "Small",
+                "isSubtle": true
+            ]
+        ]
+
+        // Build the payload
+        let payload: [String: Any] = [
+            "type": "message",
+            "attachments": [
+                [
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": [
+                        "type": "AdaptiveCard",
+                        "version": "1.4",
+                        "msteams": ["width": "full"],
+                        "body": bodyContent
+                    ]
+                ]
+            ]
+        ]
+
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: payload, options: [])
+            guard let url = URL(string: webhookURL) else {
+                Logger.error("Invalid webhook URL: \(webhookURL)", category: .core)
+                return false
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = jsonData
+
+            let (_, response) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = response as? HTTPURLResponse {
+                if (200...299).contains(httpResponse.statusCode) {
+                    Logger.log("Test notification sent successfully to Teams!", category: .core)
+                    return true
+                } else {
+                    Logger.error("Failed to send test notification. HTTP Status: \(httpResponse.statusCode)", category: .core)
+                    return false
+                }
+            }
+
+            return false
+        } catch {
+            Logger.error("Error sending test notification: \(error.localizedDescription)", category: .core)
+            return false
+        }
+    }
+
+}

--- a/IntuneomatorService/XPCService/XPCService+Settings.swift
+++ b/IntuneomatorService/XPCService/XPCService+Settings.swift
@@ -749,21 +749,67 @@ extension XPCService {
                     reply(false)
                     return
                 }
-                
+
                 let teamsNotifier = TeamsNotifier(webhookURL: webhookURL)
                 let success = await teamsNotifier.sendCustomMessage(message)
-                
+
                 if success {
                     Logger.info("Successfully sent Teams notification", category: .core)
                 } else {
                     Logger.error("Failed to send Teams notification", category: .core)
                 }
-                
+
                 reply(success)
             }
         }
     }
-    
+
+    /// Sends a test notification to verify Teams webhook configuration
+    func sendTeamsTestNotification(reply: @escaping (Bool) -> Void) {
+        Task {
+            let webhookURL = ConfigManager.readPlistValue(key: "TeamsWebhookURL") ?? ""
+            guard !webhookURL.isEmpty else {
+                Logger.error("Teams webhook URL not configured", category: .core)
+                reply(false)
+                return
+            }
+
+            let teamsNotifier = TeamsNotifier(webhookURL: webhookURL)
+            let success = await teamsNotifier.sendTestNotification()
+
+            if success {
+                Logger.info("Successfully sent Teams test notification", category: .core)
+            } else {
+                Logger.error("Failed to send Teams test notification", category: .core)
+            }
+
+            reply(success)
+        }
+    }
+
+    /// Sends a test notification to a specific webhook URL without saving it
+    func sendTeamsTestNotificationWithURL(webhookURL: String, reply: @escaping (Bool) -> Void) {
+        Task {
+            let trimmedURL = webhookURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedURL.isEmpty else {
+                Logger.error("Teams webhook URL is empty", category: .core)
+                reply(false)
+                return
+            }
+
+            let teamsNotifier = TeamsNotifier(webhookURL: trimmedURL)
+            let success = await teamsNotifier.sendTestNotification()
+
+            if success {
+                Logger.info("Successfully sent Teams test notification to provided URL", category: .core)
+            } else {
+                Logger.error("Failed to send Teams test notification to provided URL", category: .core)
+            }
+
+            reply(success)
+        }
+    }
+
     /// Lists all files in Azure Storage using a named configuration
     func listAzureStorageFiles(configurationName: String, reply: @escaping ([[String: Any]]?) -> Void) {
         Task {

--- a/SharedCode/XPCServiceProtocol.swift
+++ b/SharedCode/XPCServiceProtocol.swift
@@ -967,7 +967,17 @@ import Foundation
     ///   - message: Message content to send
     ///   - reply: Callback indicating if notification was sent successfully
     func sendTeamsNotification(message: String, reply: @escaping (Bool) -> Void)
-    
+
+    /// Sends a test notification to verify Teams webhook configuration
+    /// - Parameter reply: Callback indicating if test notification was sent successfully
+    func sendTeamsTestNotification(reply: @escaping (Bool) -> Void)
+
+    /// Sends a test notification to a specific webhook URL without saving it
+    /// - Parameters:
+    ///   - webhookURL: The webhook URL to test
+    ///   - reply: Callback indicating if test notification was sent successfully
+    func sendTeamsTestNotificationWithURL(webhookURL: String, reply: @escaping (Bool) -> Void)
+
     /// Lists all files in Azure Storage using a named configuration
     /// - Parameters:
     ///   - configurationName: Name of the Azure Storage configuration to use


### PR DESCRIPTION
Fix URL validation for Teams web hooks to the new Microsoft URL domain.
Add a test webhook button to the notification settings panel.
Add new Teams notification test function to generate a test Teams message.