### PR TITLE
MacOS 26 Tahoe support

### DIFF
--- a/Intuneomator/Base.lproj/Main.storyboard
+++ b/Intuneomator/Base.lproj/Main.storyboard
@@ -1662,6 +1662,7 @@ Gw
                                                         <menuItem title="macOS Ventura 13.0" identifier="v13_0" id="wGi-cB-eco"/>
                                                         <menuItem title="macOS Sonoma 14.0" identifier="v14_0" id="Qbd-BU-vcE"/>
                                                         <menuItem title="macOS Sequoia 15.0" identifier="v15_0" id="iAN-7c-Cxd"/>
+                                                        <menuItem title="macOS Tahoe 26.0" identifier="v15_0" id="3VR-vt-qo7"/>
                                                     </items>
                                                 </menu>
                                             </popUpButtonCell>

--- a/Intuneomator/Inspectors/AppInspectorViewController.swift
+++ b/Intuneomator/Inspectors/AppInspectorViewController.swift
@@ -203,7 +203,8 @@ class AppInspectorViewController: NSViewController {
             (OperatingSystemVersion(majorVersion: 12, minorVersion: 0, patchVersion: 0), "macOS Monterey 12.0"),
             (OperatingSystemVersion(majorVersion: 13, minorVersion: 0, patchVersion: 0), "macOS Ventura 13.0"),
             (OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0), "macOS Sonoma 14.0"),
-            (OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0), "macOS Sequoia 15.0"),
+            (OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0), "macOS Sequoia 15.0"),
+            (OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0), "macOS Tahoe 26.0"),
         ]
 
         // Parse the input version

--- a/Intuneomator/Inspectors/PkgInspectorViewController.swift
+++ b/Intuneomator/Inspectors/PkgInspectorViewController.swift
@@ -245,6 +245,7 @@ class PkgInspectorViewController: NSViewController {
             (OperatingSystemVersion(majorVersion: 13, minorVersion: 0, patchVersion: 0), "macOS Ventura 13.0"),
             (OperatingSystemVersion(majorVersion: 14, minorVersion: 0, patchVersion: 0), "macOS Sonoma 14.0"),
             (OperatingSystemVersion(majorVersion: 15, minorVersion: 0, patchVersion: 0), "macOS Sequoia 15.0"),
+            (OperatingSystemVersion(majorVersion: 26, minorVersion: 0, patchVersion: 0), "macOS Tahoe 26.0"),
         ]
 
         // Parse the input version


### PR DESCRIPTION
Add macOS 26 to the Minimum OS Support menu.