### PR TITLE
Fix Intune delete of older versions

### DIFF
--- a/Constants/Constants.swift
+++ b/Constants/Constants.swift
@@ -53,5 +53,6 @@ struct FilteredIntuneAppInfo: Codable {
     let isAssigned: Bool
     let primaryBundleId: String
     let primaryBundleVersion: String
+    let createdDateTime: String
 }
 

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
@@ -130,9 +130,10 @@ class EntraGraphRequests {
                 var primaryBundleVersion: String?
                 let bundleId: String?
                 let buildNumber: String?
+                let createdDateTime: String?
                 
                 enum CodingKeys: String, CodingKey {
-                    case id, displayName, isAssigned, primaryBundleId, primaryBundleVersion, bundleId, buildNumber
+                    case id, displayName, isAssigned, primaryBundleId, primaryBundleVersion, bundleId, buildNumber, createdDateTime
                 }
                 
                 init(from decoder: Decoder) throws {
@@ -147,6 +148,7 @@ class EntraGraphRequests {
                     primaryBundleVersion = try container.decodeIfPresent(String.self, forKey: .primaryBundleVersion)
                     bundleId = try container.decodeIfPresent(String.self, forKey: .bundleId)
                     buildNumber = try container.decodeIfPresent(String.self, forKey: .buildNumber)
+                    createdDateTime = try container.decodeIfPresent(String.self, forKey: .createdDateTime)
                 }
             }
             
@@ -158,13 +160,15 @@ class EntraGraphRequests {
                 // Use LOB app fields if primary fields are not available
                 let effectiveBundleId = app.primaryBundleId ?? app.bundleId ?? ""
                 let effectiveVersion = app.primaryBundleVersion ?? app.buildNumber ?? ""
+                let createdDateTime = app.createdDateTime ?? ""
                 
                 return FilteredIntuneAppInfo(
                     id: app.id,
                     displayName: app.displayName,
                     isAssigned: app.isAssigned,
                     primaryBundleId: effectiveBundleId,
-                    primaryBundleVersion: effectiveVersion
+                    primaryBundleVersion: effectiveVersion,
+                    createdDateTime: createdDateTime
                 )
             }
             

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
@@ -311,11 +311,10 @@ extension LabelAutomation {
                 // Clean up extra older versions of the app (AppVersionsToKeep changed?)
                 do {
                     let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
-                    let totalVersions = appInfo.count
-                    let versionsToDeleteCount = max(0, totalVersions - appVersionsToKeep)
+                    let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
+                    let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
                     if versionsToDeleteCount > 0 {
-                        // Since appInfo is sorted oldest to newest, delete the earliest ones
-                        let appsToDelete = appInfo.prefix(versionsToDeleteCount)
+                        let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
                         for app in appsToDelete {
                             guard !app.isAssigned else { continue }
                             Logger.info("Deleting older app \(app.displayName)", category: .automation)
@@ -454,7 +453,8 @@ extension LabelAutomation {
                 Logger.info("App: \(app.displayName)", category: .automation)
                 Logger.info("Version: \(app.primaryBundleVersion)", category: .automation)
                 Logger.info("Tracking ID: \(app.id)", category: .automation)
-                
+                Logger.info("Creation Date: \(app.createdDateTime)", category: .automation)
+
                 if app.primaryBundleVersion != processedAppResults.appVersionActual {
                     if app.isAssigned == true {
                         Logger.info("Older assigned version found in Intune!", category: .automation)
@@ -469,11 +469,10 @@ extension LabelAutomation {
             
             // Clean up extra older versions of the app
             let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
-            let totalVersions = appInfo.count
-            let versionsToDeleteCount = max(0, totalVersions - appVersionsToKeep)
+            let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
+            let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
             if versionsToDeleteCount > 0 {
-                // Since appInfo is sorted oldest to newest, delete the earliest ones
-                let appsToDelete = appInfo.prefix(versionsToDeleteCount)
+                let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
                 for app in appsToDelete {
                     guard !app.isAssigned else { continue }
                     Logger.info("Deleting older app \(app.displayName)", category: .automation)


### PR DESCRIPTION
Previously is assumed the returned results were pre-sorted, but that is not the case. Now results are sorted oldest to newest by creationDateTime to determine the correct item to prune from Intune.