### PR TITLE
Fix macOSLobApp exclusion-assignment settings and version-less label dedup

### DIFF
--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
@@ -234,14 +234,18 @@ class EntraGraphRequests {
             }
             
             let isVirtual = assignment["isVirtual"] as? Int == 1
-            
+            let isExclusion = mode.lowercased() == "exclude"
+
             // Create the assignment object with correct settings type for macOS
             var assignmentObject: [String: Any] = [
                 "@odata.type": "#microsoft.graph.mobileAppAssignment",
                 "intent": assignmentType.lowercased()
             ]
 
-            if appType == "macOSLobApp" {
+            // Graph rejects any assignment settings on an exclusion target
+            // ("Exclusion assignment does not support MobileAppAssignment Settings"),
+            // so only attach macOSLobApp settings to include/virtual targets.
+            if appType == "macOSLobApp" && !isExclusion {
                 if installAsManaged {
                     assignmentObject["settings"] = [
                         "@odata.type": "#microsoft.graph.macOsLobAppAssignmentSettings",

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
@@ -295,7 +295,21 @@ extension LabelAutomation {
             
             // Check Intune for an existing version
             Logger.info("  " + folderName + ": Fetching app info from Intune...", category: .automation)
-            
+
+            // If the label advertised no version (appVersionExpected == ""), the
+            // expected-version block above was skipped and appInfo was never fetched,
+            // leaving it empty. Fetch it now so the actual-version dedup below has
+            // something to compare against — otherwise a version-less label always
+            // re-uploads and duplicates the app on every run.
+            if !checkedIntune {
+                do {
+                    appInfo = try await EntraGraphRequests.findAppsByTrackingID(authToken: authToken, trackingID: appTrackingID)
+                    Logger.info("    Found \(appInfo.count) apps matching tracking ID \(appTrackingID)", category: .automation)
+                } catch {
+                    Logger.error("Failed to fetch app info from Intune: \(error.localizedDescription)", category: .automation)
+                }
+            }
+
             // Check if current actual version already exists in Intune
             let versionExistsInIntune = isVersionUploadedToIntune(appInfo: appInfo, version: processedAppResults.appVersionActual)
             


### PR DESCRIPTION
Two independent assignment/dedup bugs, one commit each.

## 1. macOSLobApp exclusion assignments (closes #66)

`assignGroupsToApp` attached `macOsLobAppAssignmentSettings` to every assignment for `macOSLobApp`, including exclusion targets. Graph rejects settings on an `exclusionGroupAssignmentTarget` with `Exclusion assignment does not support MobileAppAssignment Settings`. The call throws after the content upload, so the app is left with no assignments, and it repeats on every LOB version update that has an exclusion group.

Fix: attach the settings only to include and virtual targets.

## 2. Version-less label dedup (closes #67)

The post-download existing-version check reads `appInfo`, but `appInfo` is only fetched when the label advertised a version (`appVersionExpected != ""`). A label with no `appNewVersion` (spotify) leaves it empty, so the check always misses and the app is re-uploaded on every run.

Fix: fetch `appInfo` when it was not fetched above (`checkedIntune == false`), before the actual-version check.

## Testing

Both behaviours were reproduced live against a real Intune tenant: the 400 on the exclusion assign, and the accumulating duplicate records. The changed files pass `swiftc -parse`. I could not run a full Xcode build locally (Command Line Tools only, no Xcode.app), so please confirm the build in CI or your environment.
