### PR TITLE
Fix for missing group assignment

### DIFF
--- a/Intuneomator/CustomAttributes/CustomAttributeManagerViewController.swift
+++ b/Intuneomator/CustomAttributes/CustomAttributeManagerViewController.swift
@@ -281,7 +281,7 @@ class CustomAttributeManagerViewController: NSViewController, NSTableViewDelegat
             case "#microsoft.graph.groupAssignmentTarget":
                 if let groupId = target["groupId"] as? String {
                     transformedAssignment["groupId"] = groupId
-                    
+
                     // Check if this is a virtual group
                     if groupId == "adadadad-808e-44e2-905a-0b7873a8a531" {
                         transformedAssignment["displayName"] = "All Devices"
@@ -292,16 +292,17 @@ class CustomAttributeManagerViewController: NSViewController, NSTableViewDelegat
                     } else {
                         transformedAssignment["displayName"] = getGroupDisplayName(for: groupId)
                         transformedAssignment["isVirtual"] = false
+                        transformedAssignment["id"] = groupId  // Add id field for real groups
                     }
-                    
+
                     transformedAssignment["mode"] = "include"
                     transformedAssignment["assignmentType"] = "Required"
                 }
-                
+
             case "#microsoft.graph.exclusionGroupAssignmentTarget":
                 if let groupId = target["groupId"] as? String {
                     transformedAssignment["groupId"] = groupId
-                    
+
                     // Check if this is a virtual group (though exclude shouldn't be used for virtual groups)
                     if groupId == "adadadad-808e-44e2-905a-0b7873a8a531" {
                         transformedAssignment["displayName"] = "All Devices"
@@ -312,8 +313,9 @@ class CustomAttributeManagerViewController: NSViewController, NSTableViewDelegat
                     } else {
                         transformedAssignment["displayName"] = getGroupDisplayName(for: groupId)
                         transformedAssignment["isVirtual"] = false
+                        transformedAssignment["id"] = groupId  // Add id field for real groups
                     }
-                    
+
                     transformedAssignment["mode"] = "exclude"
                     transformedAssignment["assignmentType"] = "Required"
                 }

--- a/Intuneomator/GroupAssignment/GroupSelectionViewController.swift
+++ b/Intuneomator/GroupAssignment/GroupSelectionViewController.swift
@@ -219,6 +219,7 @@ class GroupSelectionViewController: NSViewController, NSTableViewDelegate, NSTab
             if let mode = groupSelectionModes[groupId] {
                 selections.append([
                     "id": groupId,
+                    "groupId": groupId,
                     "displayName": group["displayName"] as? String ?? "",
                     "mode": mode,
                     "isVirtual": false

--- a/Intuneomator/ShellScripts/ScriptManagerViewController.swift
+++ b/Intuneomator/ShellScripts/ScriptManagerViewController.swift
@@ -284,7 +284,7 @@ class ScriptManagerViewController: NSViewController, NSTableViewDelegate, NSTabl
             case "#microsoft.graph.groupAssignmentTarget":
                 if let groupId = target["groupId"] as? String {
                     transformedAssignment["groupId"] = groupId
-                    
+
                     // Check if this is a virtual group
                     if groupId == "adadadad-808e-44e2-905a-0b7873a8a531" {
                         transformedAssignment["displayName"] = "All Devices"
@@ -295,16 +295,17 @@ class ScriptManagerViewController: NSViewController, NSTableViewDelegate, NSTabl
                     } else {
                         transformedAssignment["displayName"] = getGroupDisplayName(for: groupId)
                         transformedAssignment["isVirtual"] = false
+                        transformedAssignment["id"] = groupId  // Add id field for real groups
                     }
-                    
+
                     transformedAssignment["mode"] = "include"
                     transformedAssignment["assignmentType"] = "Required"
                 }
-                
+
             case "#microsoft.graph.exclusionGroupAssignmentTarget":
                 if let groupId = target["groupId"] as? String {
                     transformedAssignment["groupId"] = groupId
-                    
+
                     // Check if this is a virtual group (though exclude shouldn't be used for virtual groups)
                     if groupId == "adadadad-808e-44e2-905a-0b7873a8a531" {
                         transformedAssignment["displayName"] = "All Devices"
@@ -315,8 +316,9 @@ class ScriptManagerViewController: NSViewController, NSTableViewDelegate, NSTabl
                     } else {
                         transformedAssignment["displayName"] = getGroupDisplayName(for: groupId)
                         transformedAssignment["isVirtual"] = false
+                        transformedAssignment["id"] = groupId  // Add id field for real groups
                     }
-                    
+
                     transformedAssignment["mode"] = "exclude"
                     transformedAssignment["assignmentType"] = "Required"
                 }


### PR DESCRIPTION
This fixes the issue were editing an existing Script or CustomAttribute, without touching the group assignments when saved back to Intune, would lose all assigned groups.

FIXES: https://github.com/gilburns/Intuneomator/issues/70
