### PR TITLE
Add Intune Display Name

### DIFF
--- a/Constants/Constants+Metadata.swift
+++ b/Constants/Constants+Metadata.swift
@@ -16,6 +16,7 @@ struct Metadata: Codable, Equatable {
     /// Application categories for organization in Intune portal
     var categories: [Category]
 
+
     /// Detailed description of the application's purpose and functionality
     var description: String
 
@@ -30,6 +31,9 @@ struct Metadata: Codable, Equatable {
 
     /// URL to application information or homepage
     var informationUrl: String?
+
+    /// Display name of the application that will appear in Intune and potentially Company Portal
+    var intuneDisplayName: String?
 
     /// Skip automatic version detection during updates
     var ignoreVersionDetection: Bool

--- a/Constants/Constants+ProcessedAppResults.swift
+++ b/Constants/Constants+ProcessedAppResults.swift
@@ -60,6 +60,10 @@ struct ProcessedAppResults {
     /// Application information/homepage URL
     let appInfoURL: String
     
+    /// Display name for the application in Intune. Always populated: the
+    /// metadata.json override if present, otherwise the label's plist `name`.
+    var appIntuneDisplayName: String
+
     /// Whether app should be installed with a CLI
     var appIsCliInstall: Bool
 
@@ -139,6 +143,7 @@ extension ProcessedAppResults {
     appIconURL: "",
     appIgnoreVersion: false,
     appInfoURL: "",
+    appIntuneDisplayName: "",
     appIsCliInstall: false,
     appIsDualArchCapable: false,
     appIsFeatured: false,

--- a/Intuneomator/Base.lproj/Main.storyboard
+++ b/Intuneomator/Base.lproj/Main.storyboard
@@ -1751,7 +1751,7 @@ Gw
                                                 <font key="font" metaFont="smallSystem"/>
                                             </buttonCell>
                                             <connections>
-                                                <action selector="showHelpForDeploymentType:" target="ReB-I2-ePG" id="fsR-ee-bHj"/>
+                                                <action selector="showHelpForAppDisplayName:" target="ReB-I2-ePG" id="rvQ-f7-6lN"/>
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="chl-RN-iYc">
@@ -1954,6 +1954,10 @@ Gw
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
+                                            <accessibility identifier="Name"/>
+                                            <connections>
+                                                <action selector="fieldIntuneDisplayNameDidChange:" target="ReB-I2-ePG" id="fLw-cu-n4A"/>
+                                            </connections>
                                         </textField>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UpQ-AY-fc6">
                                             <rect key="frame" x="188" y="203" width="75" height="16"/>
@@ -2373,6 +2377,7 @@ Gw
                         <outlet property="fieldDownloadURL" destination="iVX-rF-MaA" id="kpn-Om-2BO"/>
                         <outlet property="fieldExpectedTeamID" destination="jpg-7k-BdT" id="EFT-pS-QwI"/>
                         <outlet property="fieldIntuneID" destination="E9b-43-Y0G" id="4df-Nd-74u"/>
+                        <outlet property="fieldIntuneName" destination="zr4-L2-XOI" id="VJD-Kh-aDZ"/>
                         <outlet property="fieldIntuneVersion" destination="h9b-RH-wyI" id="x9g-gk-mCd"/>
                         <outlet property="fieldItemGUID" destination="cpY-sr-8nS" id="tp2-Ql-534"/>
                         <outlet property="fieldLabel" destination="Wvo-Af-CgJ" id="J25-VA-3QE"/>
@@ -3320,7 +3325,7 @@ Gw
                                                     </tableView>
                                                 </subviews>
                                             </clipView>
-                                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.86764705882352944" horizontal="YES" id="Fha-0b-bPh">
+                                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Fha-0b-bPh">
                                                 <rect key="frame" x="1" y="198" width="398" height="17"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>

--- a/Intuneomator/GroupAssignment/GroupAssignment.storyboard
+++ b/Intuneomator/GroupAssignment/GroupAssignment.storyboard
@@ -476,7 +476,7 @@
                                                 </subviews>
                                             </clipView>
                                             <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jen-7P-gg9">
-                                                <rect key="frame" x="1" y="199" width="415" height="17"/>
+                                                <rect key="frame" x="1" y="288" width="498" height="17"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="QFY-hI-hrR">

--- a/Intuneomator/ViewControllers/EditViewController+HelpButtons.swift
+++ b/Intuneomator/ViewControllers/EditViewController+HelpButtons.swift
@@ -21,6 +21,24 @@ import AppKit
 extension EditViewController {
     
     // MARK: - Help Buttons
+    /// Displays help about the "App Display Name" field.
+    /// Shows a popover explaining how the display name  is used in Intune and  Company Portal.
+    /// - Parameter sender: The help button that was clicked.
+    
+    @IBAction func showHelpForAppDisplayName(_ sender: NSButton) {
+        // Create the full string
+        let helpText = NSMutableAttributedString(string: "This is optional. If you do not enter any value the default will be the app name from the Installomator label variable.\n\nEnter the display name to override the default value. The display name will appears Intune and in the Company Portal.\n\nThe version number will automatically be appended when it appears in Intune.\n\nExample:\nLabel value = 'Firefox'\nOverride value = 'Mozilla Firefox'")
+
+        // Add custom styling for the rest of the text
+        helpText.addAttributes([
+            .foregroundColor: NSColor.textColor,
+            .font: NSFont.systemFont(ofSize: 13)
+        ], range: NSRange(location: 0, length: helpText.length))
+
+        // Show the popover
+        helpPopover.showHelp(anchorView: sender, helpText: helpText)
+    }
+
     /// Displays help about the "App Description" field.
     /// Shows a popover explaining how the description is used in the Company Portal.
     /// - Parameter sender: The help button that was clicked.

--- a/Intuneomator/ViewControllers/EditViewController+MetadataLoad.swift
+++ b/Intuneomator/ViewControllers/EditViewController+MetadataLoad.swift
@@ -122,6 +122,7 @@ extension EditViewController {
             deploymentTypeTag: 0,
             developer: "",
             informationUrl: "",
+            intuneDisplayName: "",
             ignoreVersionDetection: false,
             isCliPKG: false,
             isFeatured: false,

--- a/Intuneomator/ViewControllers/EditViewController+MetadataSave.swift
+++ b/Intuneomator/ViewControllers/EditViewController+MetadataSave.swift
@@ -66,6 +66,7 @@ extension EditViewController: TabSaveable {
             deploymentTypeTag: getDeploymentTypeTag() ?? 0,
             developer: partialDeveloper ?? "",
             informationUrl: partialInformationURL ?? "",
+            intuneDisplayName: fieldIntuneName.stringValue.trimmingCharacters(in: .whitespacesAndNewlines),
             ignoreVersionDetection: (radioNo.state == .off),
             isCliPKG: (buttonCliPkg.state == .on),
             isFeatured: (buttonFeatureApp.state == .on),

--- a/Intuneomator/ViewControllers/EditViewController+TrackChanges.swift
+++ b/Intuneomator/ViewControllers/EditViewController+TrackChanges.swift
@@ -49,6 +49,7 @@ extension EditViewController {
             deploymentTypeTag: getDeploymentTypeTag() ?? 0,
             developer: developer,
             informationUrl: informationURL,
+            intuneDisplayName: fieldIntuneName.stringValue,
             ignoreVersionDetection: (radioYes.state == .on),
             isCliPKG: (buttonCliPkg.state == .on),
             isFeatured: (buttonFeatureApp.state == .on),
@@ -162,7 +163,13 @@ extension EditViewController {
             setTextViewBorder(field: fieldLabelDescription, color: NSColor.systemYellow)
             hasUnsavedChanges = true
         }
-        
+
+        // Highlight the name field
+        if !(currentMetadata.intuneDisplayName ?? "").isEmpty {
+            highlightField(fieldIntuneName)
+            hasUnsavedChanges = true
+        }
+
 
         // Notify TabViewController about unsaved changes if any
         parentTabViewController?.updateSaveButtonState()
@@ -174,10 +181,11 @@ extension EditViewController {
     private func clearFieldHighlights() {
         clearHighlight(buttonSelectCategories)
 //        fieldInfoURL.backgroundColor = nil
-        fieldPublisher.backgroundColor = nil
+        clearHighlight(fieldIntuneName)
+        clearHighlight(fieldPublisher)
         buttonPopUpMinimumOs.layer?.backgroundColor = nil
         buttonDeployAsArch.layer?.backgroundColor = nil
-        fieldIntuneID.backgroundColor = nil
+        clearHighlight(fieldIntuneID)
         radioYes.layer?.backgroundColor = nil
         radioNo.layer?.backgroundColor = nil
         buttonCliPkg.layer?.backgroundColor = nil
@@ -199,6 +207,13 @@ extension EditViewController {
 //        } else {
 //            clearHighlight(fieldInfoURL)
 //        }
+
+        // Highlight Intune Name field if changed
+        if currentMetadata.intuneDisplayName != lastMetadata.intuneDisplayName {
+            highlightField(fieldIntuneName)
+        } else {
+            clearHighlight(fieldIntuneName)
+        }
 
         // Highlight publisher field if changed
         if currentMetadata.publisher != lastMetadata.publisher {
@@ -296,11 +311,17 @@ extension EditViewController {
 
     }
 
-    /// Applies a yellow background to the given control to indicate a changed state.
-    /// Supports `NSTextField` and `NSButton` types.
+    /// Applies a yellow highlight to the given control to indicate a changed state.
+    /// `NSTextField`s are highlighted with a border (since a bezeled text field's
+    /// `backgroundColor` is only honored while the field editor has focus, and is
+    /// otherwise painted over by the system's bezel rendering). `NSButton`s use a
+    /// layer background color, which isn't subject to that limitation.
     private func highlightField(_ field: NSControl) {
         if let textField = field as? NSTextField {
-            textField.backgroundColor = NSColor.systemYellow
+            textField.wantsLayer = true
+            textField.layer?.borderColor = NSColor.systemYellow.cgColor
+            textField.layer?.borderWidth = 2.0
+            textField.layer?.cornerRadius = 4.0
         } else if let button = field as? NSButton {
             button.layer?.backgroundColor = NSColor.systemYellow.cgColor
         }
@@ -316,7 +337,7 @@ extension EditViewController {
             button.layer?.backgroundColor = NSColor.clear.cgColor
         }
     }
-    
+
     /// Adjusts the border of an `NSTextView`'s enclosing scroll view to the specified color.
     /// Used to visually indicate changes in multiline text fields.
     func setTextViewBorder(field: NSTextView, color: NSColor) {
@@ -331,8 +352,7 @@ extension EditViewController {
         scrollView.layer?.cornerRadius = 4.0  // Optional: Rounded corners
         scrollView.wantsLayer = true  // Ensure the layer is active
     }
-
-
+    
     /// Called when the corresponding UI field value changes, triggering the change-tracking process.
     /// Invokes `trackChanges()` to re-evaluate unsaved modifications.
     /// - Parameter sender: The control that changed (e.g., `NSTextField` or `NSPopUpButton`).
@@ -431,6 +451,13 @@ extension EditViewController {
     /// Invokes `trackChanges()` to re-evaluate unsaved modifications.
     /// - Parameter sender: The control that changed (e.g., `NSTextField` or `NSPopUpButton`).
     @IBAction func radioButtonDidChange(_ sender: NSButton) {
+        trackChanges()
+    }
+
+    /// Called when the corresponding UI field value changes, triggering the change-tracking process.
+    /// Invokes `trackChanges()` to re-evaluate unsaved modifications.
+    /// - Parameter sender: The control that changed (e.g., `NSTextField` or `NSPopUpButton`).
+    @IBAction func fieldIntuneDisplayNameDidChange(_ sender: NSTextField) {
         trackChanges()
     }
 

--- a/Intuneomator/ViewControllers/EditViewController.swift
+++ b/Intuneomator/ViewControllers/EditViewController.swift
@@ -54,6 +54,9 @@ class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextSt
     /// Label indicating the managed app option.
     @IBOutlet weak var labelManagedApp: NSTextField!
 
+    /// Text field for entering the display name of the item in  Intune.
+    @IBOutlet weak var fieldIntuneName: NSTextField!
+
     /// Pop-up button for selecting deployment type (DMG, PKG, LOB).
     @IBOutlet weak var buttonDeploymentType: NSPopUpButton!
     /// Checkbox to mark the application as featured in the Company Portal.
@@ -179,6 +182,7 @@ class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextSt
     private func configureUIFromAppData() {
         guard let appData = appData else { return }
 
+        fieldIntuneName.placeholderString = appData.name
         setupCategoriesPopover()
         populateCategories()
         
@@ -349,6 +353,7 @@ class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextSt
     func populateFieldsFromAppMetadata() {
         
         // Populate UI with loaded data
+        fieldIntuneName.stringValue = appMetadata?.intuneDisplayName ?? ""
         fieldLabelDescription.string = appMetadata?.description ?? ""
         fieldPublisher.stringValue = appMetadata?.publisher ?? ""
         if let osItem = buttonPopUpMinimumOs.item(withTitle: appMetadata?.minimumOSDisplay ?? "macOS Ventura 13.0") {
@@ -395,12 +400,14 @@ class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextSt
         populateCategories() // Refresh the UI checkboxes
         updateCategoryButtonTitle() // Update the button title based on loaded categories
         
+        let intuneDisplayName = appMetadata?.intuneDisplayName ?? ""
         let developer = appMetadata?.developer ?? ""
         let informationURL = appMetadata?.informationUrl ?? ""
         let notes = appMetadata?.notes ?? ""
         let owner = appMetadata?.owner ?? ""
         let privacyInformationURL = appMetadata?.privacyInformationUrl ?? ""
         
+        appMetadata?.intuneDisplayName = intuneDisplayName
         appMetadata?.developer = developer
         appMetadata?.informationUrl = informationURL
         appMetadata?.notes = notes

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Metadata.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Metadata.swift
@@ -224,9 +224,17 @@ extension EntraGraphRequests {
         getReq.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         
         let (getData, _) = try await URLSession.shared.data(for: getReq)
-        let currentName = (try JSONSerialization.jsonObject(with: getData) as? [String:Any])?["displayName"] as? String
+        var currentName = (try JSONSerialization.jsonObject(with: getData) as? [String:Any])?["displayName"] as? String
         ?? app.appDisplayName
         let currentDataType = (try JSONSerialization.jsonObject(with: getData, options: []) as? [String:Any])?["@odata.type"] as? String ?? "#microsoft.graph.macOSLobApp"
+        
+        let newName = app.appIntuneDisplayName
+        if newName == currentName {
+            Logger.info("No change for name: \(currentName)")
+        } else {
+            Logger.info("Name changed from \(currentName) to: \(newName)")
+            currentName = newName
+        }
         
         // Prepare PATCH request for metadata update
         let updateURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/\(appId)")!
@@ -290,6 +298,6 @@ extension EntraGraphRequests {
         }
         
         Logger.info("Successfully updated metadata for app ID \(appId)", category: .core)
-        Logger.info("Successfully updated \(app.appDisplayName) metadata for app ID \(appId)", category: .core)
+        Logger.info("Successfully updated \(app.appIntuneDisplayName) metadata for app ID \(appId)", category: .core)
     }
 }

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadDMG.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadDMG.swift
@@ -42,7 +42,7 @@ extension EntraGraphRequests {
         // Generate display name with architecture information for multi-arch support
         let fileName = URL(fileURLWithPath: app.appLocalURL).lastPathComponent
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
-        let displayName = "\(app.appDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
+        let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
 
         // Construct comprehensive DMG application metadata
         var metadata: [String: Any] = [

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadLOB.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadLOB.swift
@@ -44,7 +44,7 @@ extension EntraGraphRequests {
         // Generate display name with architecture information for multi-arch support
         let fileName = URL(fileURLWithPath: app.appLocalURL).lastPathComponent
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
-        let displayName = "\(app.appDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
+        let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
         
         // Construct comprehensive LOB application metadata
         var metadata: [String: Any] = [

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadPKG.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadPKG.swift
@@ -42,7 +42,7 @@ extension EntraGraphRequests {
         // Generate display name with architecture information for multi-arch support
         let fileName = URL(fileURLWithPath: app.appLocalURL).lastPathComponent
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
-        let displayName = "\(app.appDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
+        let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
 
         // Construct comprehensive PKG application metadata
         var metadata: [String: Any] = [

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests.swift
@@ -446,7 +446,7 @@ class EntraGraphRequests {
 
         let (getData, _) = try await URLSession.shared.data(for: getReq)
         let currentName = (try JSONSerialization.jsonObject(with: getData) as? [String:Any])?["displayName"] as? String
-          ?? app.appDisplayName
+          ?? app.appIntuneDisplayName
         let currentDataType = (try JSONSerialization.jsonObject(with: getData, options: []) as? [String:Any])?["@odata.type"] as? String ?? "#microsoft.graph.macOSLobApp"
 
         if currentDataType != "#microsoft.graph.macOSPkgApp" {
@@ -504,7 +504,7 @@ class EntraGraphRequests {
         }
         
         Logger.info("Successfully updated scripts for app ID \(appId)", category: .core)
-        Logger.info("Successfully updated \(app.appDisplayName) scripts for app ID \(appId)", category: .core)
+        Logger.info("Successfully updated \(app.appIntuneDisplayName) scripts for app ID \(appId)", category: .core)
     }
 
     // MARK: - Intune Delete App Function

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+Download.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+Download.swift
@@ -136,7 +136,7 @@ extension LabelAutomation {
         let finalFilename = extractDownloadFilename(
             from: response,
             fallbackURL: url,
-            appDisplayName: processedAppResults.appDisplayName,
+            appDisplayName: processedAppResults.appIntuneDisplayName,
             appVersion: processedAppResults.appVersionExpected
         )
         

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+IntuneRemove.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+IntuneRemove.swift
@@ -42,14 +42,14 @@ extension LabelAutomation {
             return
         }
         
-        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appDisplayName)", category: .automation)
+        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appIntuneDisplayName)", category: .automation)
         Logger.info("  Label: \(processedAppResults.appLabelName)", category: .automation)
         Logger.info("  Tracking ID: \(processedAppResults.appTrackingID)", category: .automation)
         Logger.info("  Version to check: \(processedAppResults.appVersionExpected)", category: .automation)
         
         let trackingID = processedAppResults.appTrackingID
         let appLabelName = processedAppResults.appLabelName
-        let appDisplayName = processedAppResults.appDisplayName
+        let appDisplayName = processedAppResults.appIntuneDisplayName
         
         let operationId = "\(folderName)_remove"
         let statusManager = StatusNotificationManager.shared

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+IntuneUpdate.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+IntuneUpdate.swift
@@ -42,14 +42,14 @@ extension LabelAutomation {
             return
         }
         
-        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appDisplayName)", category: .automation)
+        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appIntuneDisplayName)", category: .automation)
         Logger.info("  Label: \(processedAppResults.appLabelName)", category: .automation)
         Logger.info("  Tracking ID: \(processedAppResults.appTrackingID)", category: .automation)
         Logger.info("  Version to check: \(processedAppResults.appVersionExpected)", category: .automation)
         
         let trackingID = processedAppResults.appTrackingID
         let appLabelName = processedAppResults.appLabelName
-        let appDisplayName = processedAppResults.appDisplayName
+        let appDisplayName = processedAppResults.appIntuneDisplayName
         
         let operationId = "\(folderName)_metadata"
         let statusManager = StatusNotificationManager.shared
@@ -112,7 +112,7 @@ extension LabelAutomation {
                     Logger.info("✅ Successfully updated metadata for \(app.displayName)", category: .automation)
                     
                 } catch {
-                    Logger.error("Error updating \(processedAppResults.appDisplayName) with AppID \(app.id) metadata in Intune: \(error.localizedDescription)", category: .automation)
+                    Logger.error("Error updating \(processedAppResults.appIntuneDisplayName) with AppID \(app.id) metadata in Intune: \(error.localizedDescription)", category: .automation)
                     statusManager.failOperation(operationId: operationId, errorMessage: "Failed to update metadata for \(app.displayName): \(error.localizedDescription)")
                     return
                 }
@@ -158,12 +158,12 @@ extension LabelAutomation {
             return
         }
         
-        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appDisplayName)", category: .automation)
+        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appIntuneDisplayName)", category: .automation)
         Logger.info("  Label: \(String(describing: processedAppResults.appLabelName))", category: .automation)
         
         let trackingID = processedAppResults.appTrackingID
         let appLabelName = processedAppResults.appLabelName
-        let appDisplayName = processedAppResults.appDisplayName
+        let appDisplayName = processedAppResults.appIntuneDisplayName
         Logger.info("  Tracking ID: \(trackingID)", category: .automation)
         
         let operationId = "\(folderName)_scripts"
@@ -217,7 +217,7 @@ extension LabelAutomation {
                     Logger.info("✅ Successfully updated scripts for \(app.displayName)", category: .automation)
                     
                 } catch {
-                    Logger.error("Error updating \(processedAppResults.appDisplayName) with AppID \(app.id) scripts in Intune: \(error.localizedDescription)", category: .automation)
+                    Logger.error("Error updating \(processedAppResults.appIntuneDisplayName) with AppID \(app.id) scripts in Intune: \(error.localizedDescription)", category: .automation)
                     statusManager.failOperation(operationId: operationId, errorMessage: "Failed to update scripts for \(app.displayName): \(error.localizedDescription)")
                     return
                 }
@@ -264,12 +264,12 @@ extension LabelAutomation {
             return
         }
         
-        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appDisplayName)", category: .automation)
+        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appIntuneDisplayName)", category: .automation)
         Logger.info("  Label: \(String(describing: processedAppResults.appLabelName))", category: .automation)
         
         let trackingID = processedAppResults.appTrackingID
         let appLabelName = processedAppResults.appLabelName
-        let appDisplayName = processedAppResults.appDisplayName
+        let appDisplayName = processedAppResults.appIntuneDisplayName
         Logger.info("  Tracking ID: \(trackingID)", category: .automation)
         
         let operationId = "\(folderName)_assignments"
@@ -350,7 +350,7 @@ extension LabelAutomation {
                         Logger.info("✅ Successfully updated assignments for \(app.displayName)", category: .automation)
                         
                     } catch {
-                        Logger.error("Error updating \(processedAppResults.appDisplayName) with AppID \(app.id) assignment in Intune: \(error.localizedDescription)", category: .automation)
+                        Logger.error("Error updating \(processedAppResults.appIntuneDisplayName) with AppID \(app.id) assignment in Intune: \(error.localizedDescription)", category: .automation)
                         statusManager.failOperation(operationId: operationId, errorMessage: "Failed to update assignments for \(app.displayName): \(error.localizedDescription)")
                         return
                     }

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
@@ -76,7 +76,7 @@ extension LabelAutomation {
 
         }
         
-        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appDisplayName)", category: .automation)
+        Logger.info("  Extracted ProcessedAppResults data for \(processedAppResults.appIntuneDisplayName)", category: .automation)
         
         Logger.info("  Label: \(processedAppResults.appLabelName)", category: .automation)
         Logger.info("  Tracking ID: \(processedAppResults.appTrackingID)", category: .automation)
@@ -85,7 +85,7 @@ extension LabelAutomation {
         
         let appLabelName = processedAppResults.appLabelName
         let appTrackingID = processedAppResults.appTrackingID
-        let appDisplayName = processedAppResults.appDisplayName
+        let appDisplayName = processedAppResults.appIntuneDisplayName
         
         let operationId = "\(folderName)"
         let statusManager = StatusNotificationManager.shared
@@ -107,9 +107,9 @@ extension LabelAutomation {
             authToken = try await entraAuthenticator.getEntraIDToken()
         } catch {
             Logger.error("Failed to get Entra ID Token: \(error.localizedDescription)", category: .automation)
-            let errorMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appTrackingID) failed to get Entra ID Token"
+            let errorMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appTrackingID) failed to get Entra ID Token"
             statusManager.failOperation(operationId: operationId, errorMessage: errorMessage)
-            return (errorMessage, processedAppResults.appDisplayName, "", false)
+            return (errorMessage, processedAppResults.appIntuneDisplayName, "", false)
         }
         
         // MARK: - Check Intune with expected app version
@@ -142,7 +142,7 @@ extension LabelAutomation {
                     Logger.info("    ---", category: .automation)
                     Logger.info("    Version \(processedAppResults.appVersionExpected) already exists in Intune", category: .automation)
                     statusManager.failOperation(operationId: operationId, errorMessage: "Version \(processedAppResults.appVersionExpected) already exists in Intune")
-                    return ("\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) already exists in Intune", "", "", true)
+                    return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) already exists in Intune", "", "", true)
 
                 }
                 
@@ -153,7 +153,7 @@ extension LabelAutomation {
             } catch {
                 Logger.error("Failed to fetch app info from Intune: \(error.localizedDescription)", category: .automation)
                 statusManager.failOperation(operationId: operationId, errorMessage: error.localizedDescription)
-                return ("\(processedAppResults.appDisplayName) \(processedAppResults.appTrackingID) failed to fetch app info from Intune.", "", "", false)
+                return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appTrackingID) failed to fetch app info from Intune.", "", "", false)
 
             }
         }
@@ -237,10 +237,10 @@ extension LabelAutomation {
                     let downloadType: String = processedAppResults.appLabelType
                     let downloadURL: URL = armURL
                     guard let downloadURLx86_64 = x86URL else {
-                        let errorMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) x86_64 binary not available"
+                        let errorMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) x86_64 binary not available"
                         Logger.info("  \(errorMessage)", category: .automation)
                         statusManager.failOperation(operationId: operationId, errorMessage: errorMessage)
-                        return (errorMessage, processedAppResults.appDisplayName, "", false)
+                        return (errorMessage, processedAppResults.appIntuneDisplayName, "", false)
                     }
                     let fileUploadName: String = processedAppResults.appUploadFilename
                     let expectedTeamID: String = processedAppResults.appTeamID
@@ -266,8 +266,8 @@ extension LabelAutomation {
 
                 // Attempt cleanup on processing failure
                 let _ = cleanUpTmpFiles(forAppLabel: appLabelName)
-                let errorMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) download/processing failed: \(error.localizedDescription)"
-                return (errorMessage, processedAppResults.appDisplayName, "", false)
+                let errorMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) download/processing failed: \(error.localizedDescription)"
+                return (errorMessage, processedAppResults.appIntuneDisplayName, "", false)
             }
 
         }
@@ -285,12 +285,12 @@ extension LabelAutomation {
             let deploymentTypeTag = DeploymentTypeTag(rawValue: processedAppResults.appDeploymentType) ?? .dmg
 
             do {
-                let newFileName = try MetadataLoader.finalFilename(forAppTitle: processedAppResults.appDisplayName, version: processedAppResults.appVersionActual, deploymentType: deploymentTypeTag, deploymentArch: deployAsArchTag, isDualArch: processedAppResults.appIsDualArchCapable)
+                let newFileName = try MetadataLoader.finalFilename(forAppTitle: processedAppResults.appIntuneDisplayName, version: processedAppResults.appVersionActual, deploymentType: deploymentTypeTag, deploymentArch: deployAsArchTag, isDualArch: processedAppResults.appIsDualArchCapable)
                 processedAppResults.appUploadFilename = newFileName
             } catch {
                 Logger.error("Error constructing new filename: \(error.localizedDescription)", category: .automation)
                 statusManager.failOperation(operationId: operationId, errorMessage: "Error constructing new filename: \(error.localizedDescription)")
-                return ("\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual)  download failed: \(error.localizedDescription)", "\(processedAppResults.appDisplayName)", "", false)
+                return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual)  download failed: \(error.localizedDescription)", "\(processedAppResults.appIntuneDisplayName)", "", false)
             }
             
             // Check Intune for an existing version
@@ -341,9 +341,9 @@ extension LabelAutomation {
                     Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
                 }
                 
-                let successMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) already exists in Intune"
+                let successMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) already exists in Intune"
                 statusManager.failOperation(operationId: operationId, errorMessage: "Version \(processedAppResults.appVersionActual) already exists in Intune")
-                return (successMessage, processedAppResults.appDisplayName, "", true)
+                return (successMessage, processedAppResults.appIntuneDisplayName, "", true)
             }
 
             checkedIntune = true
@@ -367,9 +367,9 @@ extension LabelAutomation {
                 // Cleanup before returning
                 let _ = cleanUpTmpFiles(forAppLabel: appLabelName)
                 
-                let returnMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual): File not found: \(localFilePath)"
+                let returnMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual): File not found: \(localFilePath)"
                 statusManager.failOperation(operationId: operationId, errorMessage: "File not found")
-                return (returnMessage, processedAppResults.appDisplayName, "", false)
+                return (returnMessage, processedAppResults.appIntuneDisplayName, "", false)
             }
 
             // Call the upload function
@@ -379,9 +379,9 @@ extension LabelAutomation {
             Logger.info("New app ID post upload: \(newAppID)", category: .automation)
             
             guard !newAppID.isEmpty else {
-                statusManager.failOperation(operationId: operationId, errorMessage: "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) failed to get AppID from upload to Intune")
+                statusManager.failOperation(operationId: operationId, errorMessage: "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) failed to get AppID from upload to Intune")
 
-                return ("\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) failed to get AppID from upload to Intune", "\(processedAppResults.appDisplayName)", "", false)
+                return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) failed to get AppID from upload to Intune", "\(processedAppResults.appIntuneDisplayName)", "", false)
             }
             
         } catch {
@@ -393,10 +393,10 @@ extension LabelAutomation {
             // Cleanup before returning
             let _ = cleanUpTmpFiles(forAppLabel: appLabelName)
             
-            let returnMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) error uploading to Intune: \(error.localizedDescription)"
-            statusManager.failOperation(operationId: operationId, errorMessage: "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) error uploading to Intune: \(error.localizedDescription)")
+            let returnMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) error uploading to Intune: \(error.localizedDescription)"
+            statusManager.failOperation(operationId: operationId, errorMessage: "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) error uploading to Intune: \(error.localizedDescription)")
 
-            return (returnMessage, processedAppResults.appDisplayName, "", false)
+            return (returnMessage, processedAppResults.appIntuneDisplayName, "", false)
         }
 
         
@@ -454,9 +454,9 @@ extension LabelAutomation {
             // Cleanup temporary files
             let _ = cleanUpTmpFiles(forAppLabel: appLabelName)
             
-            let errorMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) failed to upload to Intune"
+            let errorMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) failed to upload to Intune"
             statusManager.failOperation(operationId: operationId, errorMessage: errorMessage)
-            return (errorMessage, processedAppResults.appDisplayName, "", false)
+            return (errorMessage, processedAppResults.appIntuneDisplayName, "", false)
         }
 
         // ...continue with unassigning/removing old versions
@@ -498,7 +498,7 @@ extension LabelAutomation {
             
         } catch {
             Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
-            return ("\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) uploaded. Failed to delete older apps from Intune: \(error.localizedDescription)", "\(processedAppResults.appDisplayName)", newAppID, true)
+            return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) uploaded. Failed to delete older apps from Intune: \(error.localizedDescription)", "\(processedAppResults.appIntuneDisplayName)", newAppID, true)
         }
 
         
@@ -530,10 +530,10 @@ extension LabelAutomation {
 
         // MARK: - Return Success
         
-        let successMessage = "\(processedAppResults.appDisplayName) \(processedAppResults.appVersionActual) uploaded to Intune."
+        let successMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) uploaded to Intune."
         Logger.info("✅ Processing completed successfully: \(successMessage)", category: .automation)
         statusManager.completeOperation(operationId: operationId)
-        return (successMessage, processedAppResults.appDisplayName, newAppID, true)
+        return (successMessage, processedAppResults.appIntuneDisplayName, newAppID, true)
 
     }
     

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessHelpers.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessHelpers.swift
@@ -276,7 +276,7 @@ extension LabelAutomation {
         
         do {
             // Extract application metadata for logging
-            let labelDisplayName = processedAppResults.appDisplayName
+            let labelDisplayName = processedAppResults.appIntuneDisplayName
             let labelName = processedAppResults.appLabelName
             let finalURL: String = processedAppResults.appLocalURL
             let finalFilename = (finalURL as NSString).lastPathComponent

--- a/IntuneomatorService/TeamsNotifier/TeamsNotifier+Processor.swift
+++ b/IntuneomatorService/TeamsNotifier/TeamsNotifier+Processor.swift
@@ -89,7 +89,7 @@ extension TeamsNotifier {
         if uploadSucceeded {
             // Send success notification with complete metadata
             await teamsNotifier.sendSuccessNotification(
-                title: processedAppResults.appDisplayName,
+                title: processedAppResults.appIntuneDisplayName,
                 version: "⦿ \(processedAppResults.appVersionActual)",
                 size: size,
                 time: time,
@@ -112,7 +112,7 @@ extension TeamsNotifier {
             
             // Send failure notification with error details
             teamsNotifier.sendErrorNotification(
-                title: processedAppResults.appDisplayName,
+                title: processedAppResults.appIntuneDisplayName,
                 version: processedAppResults.appVersionActual,
                 size: size,
                 time: time,

--- a/IntuneomatorService/Utilities/MetadataLoader.swift
+++ b/IntuneomatorService/Utilities/MetadataLoader.swift
@@ -48,6 +48,7 @@ struct MetadataLoader {
         let deployAsArchTagRaw = metadata?.deployAsArchTag
         let deploymentTypeTagRaw = metadata?.deploymentTypeTag
         let description = metadata?.description
+        var validatedIntuneDisplayName = (metadata?.intuneDisplayName ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         let featured = metadata?.isFeatured ?? false
         let ignoreVersion = metadata?.ignoreVersionDetection ?? false
         let informationURL = metadata?.informationUrl ?? ""
@@ -133,6 +134,12 @@ struct MetadataLoader {
         }
 //        Logger.info("  Extracted plist and metadata for \(folderName, category: .core): name=\(validatedName), version=\(appNewVersion ?? "N/A"), downloadURL=\(validatedDownloadURL), type=\(validatedType)", logType: logType)
         
+        if validatedIntuneDisplayName.isEmpty {
+            Logger.info("⚠️  Intune display name is empty for \(validatedName). Using name instead: \(validatedName)", category: .automation)
+            Logger.info("⚠️  Intune display name is empty for \(validatedName). Using name instead: \(validatedName)", category: .core)
+            validatedIntuneDisplayName = validatedName
+        }
+        
         // calculate the file name
         var filename: String
         do {
@@ -206,6 +213,7 @@ struct MetadataLoader {
             appIconURL: validatedLabelIcon,
             appIgnoreVersion: ignoreVersion,
             appInfoURL: informationURL,
+            appIntuneDisplayName: validatedIntuneDisplayName,
             appIsCliInstall: cliPKG,
             appIsDualArchCapable: isDualArch,
             appIsFeatured: featured,
@@ -242,11 +250,18 @@ struct MetadataLoader {
     
     
     static func finalFilename(forAppTitle title: String, version: String, deploymentType: DeploymentTypeTag, deploymentArch: DeploymentArchTag, isDualArch: Bool) throws -> String {
-        
+
         guard !version.isEmpty else {
             return ""
         }
-        
+
+        // Titles may come from free-text user input (e.g. the Intune display name override),
+        // so strip characters that would otherwise be interpreted as path separators.
+        let sanitizedTitle = title
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+
         let fileName: String
         
         let fileSuffix: String = (deploymentType == .dmg) ? "dmg" : "pkg"
@@ -266,7 +281,7 @@ struct MetadataLoader {
             fileArch = "universal"
         }
         
-        fileName = "\(title)-\(version)-\(fileArch).\(fileSuffix)"
+        fileName = "\(sanitizedTitle)-\(version)-\(fileArch).\(fileSuffix)"
 
         return fileName
     }

--- a/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
+++ b/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
@@ -394,6 +394,7 @@ extension XPCService {
                     deploymentTypeTag: deploymentTypeTag,
                     developer: publisherURLFromPlist,
                     informationUrl: documentationURLFromPlist,
+                    intuneDisplayName: "",
                     ignoreVersionDetection: false,
                     isCliPKG: isCLI,
                     isFeatured: false,


### PR DESCRIPTION
This change adds in the ability to control the display name of a software item as it appears in Intune and Company Portal. Previously it would default to the Installomator label variable for 'name'. It still does, but can be overridden.

This change addresses the item mentioned in this issue:
https://github.com/gilburns/Intuneomator/issues/73