### PR TITLE
Fix Process() in all functions to capture standardError correctly

### DIFF
--- a/Intuneomator/CertificateGenerator/CertificateGenerator.swift
+++ b/Intuneomator/CertificateGenerator/CertificateGenerator.swift
@@ -27,12 +27,19 @@ class CertificateGenerator {
         process.arguments = arguments
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
+
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         try process.run()
         process.waitUntilExit()
 
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(arguments): \(errorOutput)", category: .core)
+        }
+        
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         if let output = String(data: data, encoding: .utf8) {
             Logger.debug("\(output)", category: .debug)
@@ -104,11 +111,17 @@ class CertificateGenerator {
         process.arguments = ["x509", "-noout", "-fingerprint", "-sha1", "-inform", "pem", "-in", certificatePath]
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         try process.run()
         process.waitUntilExit()
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(certificatePath): \(errorOutput)", category: .core)
+        }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8), process.terminationStatus == 0 else {

--- a/Intuneomator/ViewControllers/EditViewController+Download.swift
+++ b/Intuneomator/ViewControllers/EditViewController+Download.swift
@@ -674,10 +674,17 @@ extension EditViewController {
         process.arguments = ["imageinfo", path, "-plist"]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
         process.launch()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
+
         guard process.terminationStatus == 0 else {
             Logger.info("Error: Failed to check for SLA in DMG.", category: .core, toUserDirectory: true)
             return false
@@ -708,8 +715,9 @@ extension EditViewController {
         process.arguments = ["convert", "-format", "UDRW", "-o", tempFileURL.path, path]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
@@ -725,6 +733,11 @@ extension EditViewController {
             }
         }
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
+
         guard process.terminationStatus == 0 else {
             Logger.info("Error: hdiutil failed to convert DMG with SLA.", category: .core, toUserDirectory: true)
             return false

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+DownloadHelpers.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+DownloadHelpers.swift
@@ -89,11 +89,19 @@ extension LabelAutomation {
         process.arguments = ["-q", zipURL.path, "-d", extractFolder.path]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
+        process.standardError = errorPipe
         
         try process.run()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(zipURL.path): \(errorOutput)", category: .core)
+        }
+
+
         // Verify successful extraction
         guard process.terminationStatus == 0 else {
             throw NSError(domain: "ExtractionError", code: 201, userInfo: [NSLocalizedDescriptionKey: "Failed to extract ZIP file"])
@@ -131,11 +139,18 @@ extension LabelAutomation {
         process.arguments = ["-x", "-k", zipURL.path, extractFolder.path]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
+        process.standardError = errorPipe
         
         try process.run()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(zipURL.path): \(errorOutput)", category: .core)
+        }
+
         // Verify successful extraction
         guard process.terminationStatus == 0 else {
             throw NSError(domain: "ExtractionError", code: 201, userInfo: [NSLocalizedDescriptionKey: "Failed to extract ZIP file with ditto"])
@@ -171,11 +186,18 @@ extension LabelAutomation {
         process.arguments = ["-xf", tbzURL.path, "-C", extractFolder.path]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
+        process.standardError = errorPipe
         
         try process.run()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(tbzURL.path): \(errorOutput)", category: .core)
+        }
+
         // Verify successful extraction
         guard process.terminationStatus == 0 else {
             throw NSError(domain: "ExtractionError", code: 202, userInfo: [NSLocalizedDescriptionKey: "Failed to extract TBZ file"])
@@ -272,10 +294,18 @@ extension LabelAutomation {
         process.arguments = ["imageinfo", path, "-plist"]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
+        
         process.launch()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
+
         // Verify command executed successfully
         guard process.terminationStatus == 0 else {
             Logger.error("Error: Failed to check for SLA in DMG.", category: .automation)
@@ -308,8 +338,9 @@ extension LabelAutomation {
         process.arguments = ["convert", "-format", "UDRW", "-o", tempFileURL.path, path]
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         do {
             try process.run()
@@ -323,6 +354,11 @@ extension LabelAutomation {
             process.terminationHandler = { _ in
                 continuation.resume()
             }
+        }
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
         }
 
         // Verify conversion completed successfully
@@ -370,6 +406,11 @@ extension LabelAutomation {
         try process.run()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(mountPoint): \(errorOutput)", category: .core)
+        }
+
         // Log success or failure with detailed error information
         if process.terminationStatus == 0 {
             Logger.info("  DMG unmounted successfully", category: .automation)

--- a/IntuneomatorService/LabelAutomation/LabelAutomation.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation.swift
@@ -192,16 +192,22 @@ class LabelAutomation {
         // Call `/usr/bin/file` on that binary with proper resource management
         let process = Process()
         let pipe = Pipe()
+        let errorPipe = Pipe()
         
         process.executableURL = URL(fileURLWithPath: fileToolPath)
         process.arguments = ["-bL", binaryURL.path] // -b for brief, -L to follow symlinks
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(appURL.path): \(errorOutput)", category: .core)
+            }
+
             // Ensure file handle is properly closed
             let fileHandle = pipe.fileHandleForReading
             let outputData = fileHandle.readDataToEndOfFile()

--- a/IntuneomatorService/Utilities/DaemonUpdateManager.swift
+++ b/IntuneomatorService/Utilities/DaemonUpdateManager.swift
@@ -263,13 +263,19 @@ class DaemonUpdateManager {
         process.arguments = ["-f", guiAppBundlePath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe() // Suppress error output
+        process.standardError = errorPipe
         
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent): \(errorOutput)", category: .core)
+            }
+
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             
@@ -306,12 +312,19 @@ class DaemonUpdateManager {
         process.arguments = ["-f", guiAppBundlePath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent): \(errorOutput)", category: .core)
+            }
+
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             

--- a/IntuneomatorService/Utilities/IconExporter.swift
+++ b/IntuneomatorService/Utilities/IconExporter.swift
@@ -71,13 +71,19 @@ class IconExporter {
         process.arguments = ["-s", "format", "png", icnsPath, "--out", outputPath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(appPath): \(errorOutput)", category: .core)
+            }
+
             // Check conversion success via process exit code
             if process.terminationStatus == 0 {
                 Logger.info("✅ Icon converted successfully to: \(outputPath)", category: .core)

--- a/IntuneomatorService/Utilities/KeychainManager.swift
+++ b/IntuneomatorService/Utilities/KeychainManager.swift
@@ -539,13 +539,19 @@ class KeychainManager {
         process.arguments = args
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(args): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
             

--- a/IntuneomatorService/Utilities/ScheduledTaskManager.swift
+++ b/IntuneomatorService/Utilities/ScheduledTaskManager.swift
@@ -167,11 +167,17 @@ class ScheduledTaskManager {
         process.arguments = args
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         try process.run()
         process.waitUntilExit()
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(args): \(errorOutput)", category: .core)
+        }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         return String(data: data, encoding: .utf8) ?? ""

--- a/IntuneomatorService/XPCService/XPCService.swift
+++ b/IntuneomatorService/XPCService/XPCService.swift
@@ -124,13 +124,19 @@ class XPCService: NSObject, XPCServiceProtocol {
         process.arguments = ["--version"]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe() // Suppress error output
+        process.standardError = errorPipe
         
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent): \(errorOutput)", category: .core)
+            }
+
             let data = pipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             

--- a/IntuneomatorUpdater/main.swift
+++ b/IntuneomatorUpdater/main.swift
@@ -144,12 +144,18 @@ func installPackage(at path: String, target: String) -> Bool {
     process.arguments = ["-pkg", path, "-target", target]
 
     let pipe = Pipe()
+    let errorPipe = Pipe()
     process.standardOutput = pipe
-    process.standardError = pipe
+    process.standardError = errorPipe
 
     do {
         try process.run()
         process.waitUntilExit()
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
 
         let outputData = pipe.fileHandleForReading.readDataToEndOfFile()
         pipe.fileHandleForReading.closeFile()
@@ -175,13 +181,19 @@ func checkDaemonLoaded(_ launchDaemonLabel: String) -> DaemonLoadStatus {
     task.arguments = ["list", launchDaemonLabel]
     
     let pipe = Pipe()
+    let errorPipe = Pipe()
     task.standardOutput = pipe
-    task.standardError = pipe
+    task.standardError = errorPipe
     
     do {
         try task.run()
         task.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(launchDaemonLabel): \(errorOutput)", category: .core)
+        }
+
         _ = pipe.fileHandleForReading.readDataToEndOfFile()
         pipe.fileHandleForReading.closeFile()
         

--- a/SharedCode/App Dmg Pkg/AdobeCCPkgCreator.swift
+++ b/SharedCode/App Dmg Pkg/AdobeCCPkgCreator.swift
@@ -134,6 +134,11 @@ class AdobeCCPkgCreator {
         inputPipe.fileHandleForWriting.closeFile()
         process.waitUntilExit()
 
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
+
         guard process.terminationStatus == 0 else {
             let errorOutput = String(data: errorPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "Unknown error"
             log("Error: Failed to mount .dmg file. \(errorOutput)")
@@ -165,13 +170,19 @@ class AdobeCCPkgCreator {
         process.arguments = ["detach", mountPoint, "-quiet"]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(mountPoint): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -381,13 +392,19 @@ exit "${exitCode}"
         process.arguments = ["--analyze", "--root", packageRoot, componentPlistPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -441,13 +458,19 @@ exit "${exitCode}"
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -476,13 +499,19 @@ exit "${exitCode}"
         process.arguments = ["--synthesize", "--package", componentPackage, distributionXMLPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(componentPackage): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -557,13 +586,19 @@ exit "${exitCode}"
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(distributionXML): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 

--- a/SharedCode/App Dmg Pkg/CLIAppPkgCreator.swift
+++ b/SharedCode/App Dmg Pkg/CLIAppPkgCreator.swift
@@ -175,7 +175,9 @@ class CLIAppPkgCreator {
         process.arguments = [fullExecutablePath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
@@ -186,6 +188,11 @@ class CLIAppPkgCreator {
         
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(appPath): \(errorOutput)", category: .core)
+        }
+
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8) else {
             return "unknown"
@@ -260,13 +267,19 @@ class CLIAppPkgCreator {
         process.arguments = ["detach", mountPoint, "-quiet"]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(mountPoint): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -432,13 +445,19 @@ exit "${exitCode}"
         process.arguments = ["--analyze", "--root", packageRoot, componentPlistPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -492,13 +511,19 @@ exit "${exitCode}"
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -527,13 +552,19 @@ exit "${exitCode}"
         process.arguments = ["--synthesize", "--package", componentPackage, distributionXMLPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(componentPackage): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -608,13 +639,19 @@ exit "${exitCode}"
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(distributionXML): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 

--- a/SharedCode/App Dmg Pkg/DMGCreator.swift
+++ b/SharedCode/App Dmg Pkg/DMGCreator.swift
@@ -118,7 +118,9 @@ class DMGCreator {
         process.arguments = [fullExecutablePath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
@@ -129,6 +131,11 @@ class DMGCreator {
         
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(appPath): \(errorOutput)", category: .core)
+        }
+
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8) else {
             return "unknown"
@@ -156,13 +163,19 @@ class DMGCreator {
         process.arguments = arguments
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             try process.run()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(command): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
             

--- a/SharedCode/App Dmg Pkg/PKGCreator.swift
+++ b/SharedCode/App Dmg Pkg/PKGCreator.swift
@@ -169,8 +169,10 @@ class PKGCreator {
         process.arguments = [fullExecutablePath]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        
+        process.standardError = errorPipe
+
         do {
             try process.run()
         } catch {
@@ -180,6 +182,11 @@ class PKGCreator {
         
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(appPath): \(errorOutput)", category: .core)
+        }
+
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let output = String(data: data, encoding: .utf8) else {
             return "unknown"
@@ -206,9 +213,17 @@ class PKGCreator {
         process.arguments = ["imageinfo", path, "-plist"]
 
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
+        process.standardError = errorPipe
+
         process.launch()
         process.waitUntilExit()
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
 
         guard process.terminationStatus == 0 else {
             log("Error: Failed to check for SLA in DMG.")
@@ -239,8 +254,9 @@ class PKGCreator {
         process.arguments = ["convert", "-format", "UDRW", "-o", tempFileURL.path, path]
         
         let pipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
         
         do {
             try process.run()
@@ -256,6 +272,11 @@ class PKGCreator {
             }
         }
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+        }
+
         guard process.terminationStatus == 0 else {
             log("Error: hdiutil failed to convert DMG with SLA.")
             return false
@@ -346,13 +367,19 @@ class PKGCreator {
         process.arguments = ["detach", mountPoint, "-quiet"]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(mountPoint): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -381,12 +408,18 @@ class PKGCreator {
             process.arguments = ["-x", "-k", path, destinationPath]
 
             let outputPipe = Pipe()
+            let errorPipe = Pipe()
             process.standardOutput = outputPipe
-            process.standardError = outputPipe
+            process.standardError = errorPipe
 
             do {
                 process.launch()
                 process.waitUntilExit()
+                
+                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                    Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+                }
                 
                 let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 let output = String(data: outputData, encoding: .utf8) ?? ""
@@ -424,13 +457,19 @@ class PKGCreator {
             process.arguments = ["-xf", path, "-C", destinationPath]
 
             let outputPipe = Pipe()
+            let errorPipe = Pipe()
             process.standardOutput = outputPipe
-            process.standardError = outputPipe
+            process.standardError = errorPipe
 
             do {
                 process.launch()
                 process.waitUntilExit()
                 
+                let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                    Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
+                }
+
                 let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -534,13 +573,19 @@ class PKGCreator {
         process.arguments = ["--analyze", "--root", packageRoot, componentPlistPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -593,13 +638,19 @@ class PKGCreator {
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(packageRoot): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -628,13 +679,19 @@ class PKGCreator {
         process.arguments = ["--synthesize", "--package", componentPackage, distributionXMLPath]
 
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(componentPackage): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 
@@ -709,13 +766,19 @@ class PKGCreator {
         ]
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
 
         do {
             process.launch()
             process.waitUntilExit()
             
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+                Logger.info(" stderr from |(executableURL.lastPathComponent) with \(distributionXML): \(errorOutput)", category: .core)
+            }
+
             let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
             let output = String(data: outputData, encoding: .utf8) ?? ""
 

--- a/SharedCode/App Dmg Pkg/PKGCreatorUniversal.swift
+++ b/SharedCode/App Dmg Pkg/PKGCreatorUniversal.swift
@@ -206,12 +206,18 @@ class PKGCreatorUniversal {
         process.arguments = Array(args.dropFirst())
         
         let outputPipe = Pipe()
+        let errorPipe = Pipe()
         process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        process.standardError = errorPipe
         
         process.launch()
         process.waitUntilExit()
         
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(args): \(errorOutput)", category: .core)
+        }
+
         let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
         let output = String(data: outputData, encoding: .utf8) ?? ""
         

--- a/SharedCode/App Dmg Pkg/SignatureInspector.swift
+++ b/SharedCode/App Dmg Pkg/SignatureInspector.swift
@@ -43,17 +43,23 @@ class SignatureInspector {
 
         let process = Process()
         let pipe = Pipe()
-
+        let errorPipe = Pipe()
+        
         process.executableURL = URL(fileURLWithPath: "/usr/sbin/spctl")
         process.arguments = ["-a", "-vv", "-t", type, path]
         process.standardOutput = pipe
-        process.standardError = pipe
+        process.standardError = errorPipe
 
         do {
             try process.run()
             process.waitUntilExit()
         } catch {
             throw InspectionError.spctlError("Failed to execute spctl command.")
+        }
+
+        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+        if let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines), !errorOutput.isEmpty {
+            Logger.info(" stderr from |(executableURL.lastPathComponent) with \(path): \(errorOutput)", category: .core)
         }
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()


### PR DESCRIPTION
Fix Process() in all functions to capture standardError correctly

Previously standardError was being directed into the same pipe as standardOutput. Now they are separate.