### PR TITLE
Add ability to pause updates for any automation

### DIFF
--- a/Intuneomator/Base.lproj/Main.storyboard
+++ b/Intuneomator/Base.lproj/Main.storyboard
@@ -1460,14 +1460,25 @@ Gw
                                 </connections>
                             </button>
                             <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q7q-vD-qPb">
-                                <rect key="frame" x="746" y="723" width="36" height="36"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                <rect key="frame" x="382" y="12" width="36" height="36"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="EOz-r7-rZs">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
                                     <action selector="findApps:" target="yFK-XC-1Jv" id="uac-xx-M7Q"/>
+                                </connections>
+                            </button>
+                            <button toolTip="Pause Updates" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="smb-B7-Uhl">
+                                <rect key="frame" x="744" y="720" width="36" height="42"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="stop.circle" catalog="system" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="IjH-bH-ZeR">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="toggleActiveAutomation:" target="yFK-XC-1Jv" id="Tyh-NT-ggG"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -1487,6 +1498,7 @@ Gw
                     </view>
                     <connections>
                         <outlet property="buttonCustomOnOff" destination="m5S-KN-2Ng" id="Gtd-nP-bLy"/>
+                        <outlet property="buttonPauseUpdates" destination="smb-B7-Uhl" id="r3f-O2-ohD"/>
                         <outlet property="cancelButton" destination="Hpz-vv-0i0" id="KnY-Rf-Pek"/>
                         <outlet property="imageCloudStatus" destination="Q7q-vD-qPb" id="GGT-k7-P3k"/>
                         <outlet property="labelAppName" destination="rEi-MS-ArC" id="CEp-O7-mHE"/>
@@ -3913,6 +3925,7 @@ Gw
         <image name="edit" width="128" height="128"/>
         <image name="eye" catalog="system" width="21" height="13"/>
         <image name="gear" catalog="system" width="17" height="16"/>
+        <image name="stop.circle" catalog="system" width="15" height="15"/>
         <image name="trash.square" catalog="system" width="15" height="14"/>
     </resources>
 </document>

--- a/Intuneomator/MainViewController+TableView.swift
+++ b/Intuneomator/MainViewController+TableView.swift
@@ -187,10 +187,17 @@ extension MainViewController: NSTableViewDataSource, NSTableViewDelegate {
             isValid = AutomationCheck.validateFolder(at: folderURL.path)
             validationCache[folderURL.path] = isValid
         }
+        // Paused automation takes precedence over readiness validation
+        let isPaused = FileManager.default.fileExists(atPath: folderURL.appendingPathComponent(".pauseUpdates").path)
+
         var readyState: String?
         var iconImage: NSImage!
-        // Load the appropriate icon based on validation
-        if isValid {
+        // Load the appropriate icon based on pause state and validation
+        if isPaused {
+            readyState = String("Automation Paused")
+            iconImage = AutomationStatusImage.Paused.image
+        }
+        else if isValid {
             readyState = String("Ready for Automation")
             iconImage = AutomationStatusImage.Ready.image
         }

--- a/Intuneomator/Utilities/AutomationStatusImage.swift
+++ b/Intuneomator/Utilities/AutomationStatusImage.swift
@@ -8,7 +8,7 @@
 import Cocoa
 
 enum AutomationStatusImage: Int {
-    case Ready, NotReady
+    case Ready, NotReady, Paused
 
     var image: NSImage {
         switch self {
@@ -16,6 +16,8 @@ enum AutomationStatusImage: Int {
             return NSImage(named: "NSStatusAvailable")!
         case .NotReady:
             return NSImage(named: "NSStatusPartiallyAvailable")!
+        case .Paused:
+            return NSImage(named: "NSStatusUnavailable")!
         }
     }
 }

--- a/Intuneomator/ViewControllers/TabViewController.swift
+++ b/Intuneomator/ViewControllers/TabViewController.swift
@@ -28,6 +28,9 @@ class TabViewController: NSViewController {
     /// Label displaying the name of the application being edited
     @IBOutlet weak var labelAppName: NSTextField!
     
+    /// Button to pause update automation for the given title
+    @IBOutlet weak var buttonPauseUpdates: NSButton!
+
     /// Image view showing cloud upload status with visual indicators
     @IBOutlet weak var imageCloudStatus: NSButton!
 
@@ -124,6 +127,7 @@ class TabViewController: NSViewController {
 
         checkCustomLabel()
         setToggleCustomButtonAvailability()
+        checkPauseUpdatesState()
 
         // Save current window size for next session
         if let window = view.window {
@@ -252,8 +256,37 @@ class TabViewController: NSViewController {
         }
     }
 
+    // MARK: - Pause Update Management Methods
+
+    /// Handles pausing of the updates for the given label
+    /// Switches between active and paused label via XPC service
+    /// Updates UI button and notifies other components of changes
+    /// - Parameter sender: The toggle switch that triggered the action
+    @IBAction func toggleActiveAutomation(_ sender: NSButton) {
+        let labelName = appData?.label ?? ""
+        let labelGuid = appData?.guid ?? ""
+        let directoryPath = "\(labelName)_\(labelGuid)"
+
+        // Determine desired new state from the button's current tint color.
+        // Red indicates automation is currently paused; green indicates it is active.
+        let isCurrentlyPaused = (sender.contentTintColor == .systemRed)
+        let newPausedState = !isCurrentlyPaused
+
+        XPCManager.shared.toggleActiveAutomation(directoryPath, newPausedState) { success in
+            if success! {
+                DispatchQueue.main.async {
+                    sender.contentTintColor = newPausedState ? .systemRed : .systemGreen
+                    sender.toolTip = newPausedState ? "Resume Updates" : "Pause Updates"
+                }
+            } else {
+                Logger.info("Toggle Pause Updates Failed: \(directoryPath)", category: .core, toUserDirectory: true)
+            }
+        }
+    }
+
+
     // MARK: - Custom Label Management Methods
-    
+
     /// Handles custom Installomator label toggle switch changes
     /// Switches between standard and custom label implementations via XPC service
     /// Updates UI visual indicators and notifies other components of changes
@@ -646,6 +679,25 @@ class TabViewController: NSViewController {
         } else {
             labelCustomLabel.textColor = .lightGray
             buttonCustomOnOff.state = .off
+        }
+    }
+
+    /// Checks whether automation is currently paused for this label and updates the
+    /// pause/resume button's icon tint to reflect the current state.
+    /// Green indicates automation is active; red indicates it is paused.
+    private func checkPauseUpdatesState() {
+        let labelFolder = "\(appData!.label)_\(appData!.guid)"
+
+        let pauseCheckURL = AppConstants.intuneomatorManagedTitlesFolderURL
+            .appendingPathComponent(labelFolder)
+            .appendingPathComponent(".pauseUpdates")
+
+        if FileManager.default.fileExists(atPath: pauseCheckURL.path) {
+            buttonPauseUpdates.contentTintColor = .systemRed
+            buttonPauseUpdates.toolTip = "Resume Updates"
+        } else {
+            buttonPauseUpdates.contentTintColor = .systemGreen
+            buttonPauseUpdates.toolTip = "Pause Updates"
         }
     }
 

--- a/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
+++ b/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
@@ -134,7 +134,16 @@ extension XPCManager {
         sendRequest({ $0.toggleCustomLabel(labelDirectory, toggle, reply: $1) }, completion: completion)
     }
 
-    
+    /// Pauses or resumes automation for a managed label by creating or removing a `.pauseUpdates` marker file
+    /// - Parameters:
+    ///   - labelDirectory: Name of the label folder to modify
+    ///   - toggle: True to pause automation, false to resume
+    ///   - completion: Callback with toggle operation success status or nil on XPC failure
+    func toggleActiveAutomation(_ labelDirectory: String, _ toggle: Bool, completion: @escaping (Bool?) -> Void) {
+        sendRequest({ $0.toggleActiveAutomation(labelDirectory, toggle, reply: $1) }, completion: completion)
+    }
+
+
     // MARK: - Icon Management Operations
     
     /// Imports an icon file or extracts icon from application bundle for a label

--- a/IntuneomatorService/Utilities/FolderScanner.swift
+++ b/IntuneomatorService/Utilities/FolderScanner.swift
@@ -25,7 +25,11 @@ struct FolderScanner {
 
             for folderName in folderContents {
                 let folderPath = (basePath as NSString).appendingPathComponent(folderName)
-                if AutomationCheck.validateFolder(at: folderPath) {
+                let pauseUpdatesPath = (folderPath as NSString).appendingPathComponent(".pauseUpdates")
+
+                if FileManager.default.fileExists(atPath: pauseUpdatesPath) {
+                    Logger.info("⏸️ Automation paused: \(folderName)", category: .core)
+                } else if AutomationCheck.validateFolder(at: folderPath) {
                     Logger.info("✅ Ready for automation: \(folderName)", category: .core)
                     validFolders.append(folderName)
                 } else {

--- a/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
+++ b/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
@@ -568,7 +568,39 @@ extension XPCService {
         }
     }
 
-    
+    /// Pauses or resumes automation for a managed label by creating or removing a `.pauseUpdates` marker file
+    /// - Parameters:
+    ///   - labelFolder: Name of the label folder to modify
+    ///   - toggle: True to pause automation (create marker file), false to resume (remove marker file)
+    ///   - reply: Callback with success status of the toggle operation
+    func toggleActiveAutomation(_ labelFolder: String, _ toggle: Bool, reply: @escaping (Bool) -> Void) {
+
+        let labelFolderURL = AppConstants.intuneomatorManagedTitlesFolderURL
+            .appendingPathComponent(labelFolder)
+
+        let touchFileURL = labelFolderURL
+            .appendingPathComponent(".pauseUpdates")
+
+        if toggle {
+            let success = FileManager.default.createFile(atPath: touchFileURL.path, contents: nil, attributes: nil)
+            if !success {
+                Logger.error("Failed to create pause updates touch file for \(labelFolder)", category: .core)
+            }
+            reply(success)
+        } else {
+            do {
+                if FileManager.default.fileExists(atPath: touchFileURL.path) {
+                    try FileManager.default.removeItem(at: touchFileURL)
+                }
+                reply(true)
+            } catch {
+                Logger.error("Failed to delete pause updates touch file for \(labelFolder): \(error.localizedDescription)", category: .core)
+                reply(false)
+            }
+        }
+    }
+
+
     // MARK: - Icon Management Operations
     
     /// Imports an icon file or extracts icon from application bundle for a label

--- a/SharedCode/XPCServiceProtocol.swift
+++ b/SharedCode/XPCServiceProtocol.swift
@@ -148,6 +148,13 @@ import Foundation
     ///   - reply: Callback indicating if toggle was successful
     func toggleCustomLabel(_ labelFolder: String, _ toggle: Bool, reply: @escaping (Bool) -> Void)
 
+    /// Toggles paused-automation status for a managed folder by creating or removing a `.pauseUpdates` marker file
+    /// - Parameters:
+    ///   - labelFolder: Target label folder name
+    ///   - toggle: True to pause automation (create marker file), false to resume (remove marker file)
+    ///   - reply: Callback indicating if toggle was successful
+    func toggleActiveAutomation(_ labelFolder: String, _ toggle: Bool, reply: @escaping (Bool) -> Void)
+
     // MARK: - Label Editing Operations
     
     /// Imports a custom icon file to a label folder


### PR DESCRIPTION
Pausing the update will keep the automation intact and ready to go, but will remain on the version when it was paused until such time as the automation is unpaused. New button on the edit view to toggle the pause on or off.