### PR TITLE
Single App Policy Mode

### DIFF
--- a/Constants/Constants+Metadata.swift
+++ b/Constants/Constants+Metadata.swift
@@ -47,6 +47,10 @@ struct Metadata: Codable, Equatable {
     /// Whether the app is managed (has configuration policies applies to LOB type only)
     var isManaged: Bool
 
+    /// Reuse a single Intune app record across versions (patch content/version in place)
+    /// instead of creating a new app record for every version
+    var useSingleAppPolicy: Bool?
+
     /// Minimum macOS version required (e.g., "14.0")
     var minimumOS: String
 

--- a/Constants/Constants+ProcessedAppResults.swift
+++ b/Constants/Constants+ProcessedAppResults.swift
@@ -75,7 +75,11 @@ struct ProcessedAppResults {
     
     /// Whether app has configuration policies (LOB only)
     let appIsManaged: Bool
-    
+
+    /// Whether this title reuses a single existing Intune app record across versions
+    /// instead of creating a new one for every version
+    let appUseSingleAppPolicy: Bool
+
     /// Installomator label name used for processing
     let appLabelName: String
     
@@ -148,6 +152,7 @@ extension ProcessedAppResults {
     appIsDualArchCapable: false,
     appIsFeatured: false,
     appIsManaged: false,
+    appUseSingleAppPolicy: false,
     appLabelName: "",
     appLabelType: "",
     appLocalURL: "",

--- a/Intuneomator/Base.lproj/Main.storyboard
+++ b/Intuneomator/Base.lproj/Main.storyboard
@@ -2366,6 +2366,33 @@ Gw
                                     </subviews>
                                 </view>
                             </box>
+                            <button horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3Xy-FJ-heG">
+                                <rect key="frame" x="696" y="599" width="24" height="24"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ICT-ZC-dha">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="showHelpForSingleAppPolicy:" target="ReB-I2-ePG" id="kry-0k-xFP"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Spa-01-Chk">
+                                <rect key="frame" x="561" y="602" width="127" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                <string key="toolTip">Reuse a single Intune app record across versions instead of creating a new one for every version. Turning this on when duplicate records already exist will prompt to consolidate them.</string>
+                                <buttonCell key="cell" type="check" title="Single App Policy" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Spa-02-Cel">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="buttonSingleAppPolicyDidChange:" target="ReB-I2-ePG" id="Spa-03-Act"/>
+                                </connections>
+                            </button>
+                            <progressIndicator fixedFrame="YES" maxValue="100" displayedWhenStopped="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="UcO-1P-geu">
+                                <rect key="frame" x="537" y="603" width="16" height="16"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                            </progressIndicator>
                         </subviews>
                     </view>
                     <connections>
@@ -2380,6 +2407,7 @@ Gw
                         <outlet property="buttonPopUpMinimumOs" destination="35w-Np-gFu" id="CVo-1i-djO"/>
                         <outlet property="buttonPreviewLabel" destination="zYf-2P-bnN" id="4py-Xc-J6M"/>
                         <outlet property="buttonSelectCategories" destination="chl-RN-iYc" id="wg0-RQ-73m"/>
+                        <outlet property="buttonSingleAppPolicy" destination="Spa-01-Chk" id="Spa-04-Out"/>
                         <outlet property="fieldAppNewVersion" destination="bbR-An-aq9" id="rC6-4y-r6f"/>
                         <outlet property="fieldDeloyAsAdobeCCPkg" destination="1cr-oF-VfT" id="88E-R8-Fms"/>
                         <outlet property="fieldDeloyAsArchUniversal" destination="tPI-cn-AxM" id="iCw-Ns-gvj"/>
@@ -2405,6 +2433,7 @@ Gw
                         <outlet property="menuItemUniversalPkg" destination="fZm-Ej-R3q" id="Sjk-sR-Gd4"/>
                         <outlet property="progImageEdit" destination="UQC-om-L1Z" id="T6g-pe-ETe"/>
                         <outlet property="progPkgInspect" destination="l3Z-fp-jr9" id="paS-pc-jfC"/>
+                        <outlet property="progSingleAppPolicy" destination="UcO-1P-geu" id="1Kx-c9-BF4"/>
                         <outlet property="radioNo" destination="05v-kt-o8i" id="5SF-a5-m9g"/>
                         <outlet property="radioYes" destination="P7t-UB-VZI" id="QdS-IM-4qN"/>
                     </connections>

--- a/Intuneomator/ViewControllers/EditViewController+HelpButtons.swift
+++ b/Intuneomator/ViewControllers/EditViewController+HelpButtons.swift
@@ -21,6 +21,24 @@ import AppKit
 extension EditViewController {
     
     // MARK: - Help Buttons
+    /// Displays help about the "Single App Policy" button.
+    /// Shows a popover explaining how the single app policy effects Intune and  Company Portal.
+    /// - Parameter sender: The help button that was clicked.
+    
+    @IBAction func showHelpForSingleAppPolicy(_ sender: NSButton) {
+        // Create the full string
+        let helpText = NSMutableAttributedString(string: "Reuse a single Intune app record across every new versions instead of creating a new one for every version.\n\nTurning this on when duplicate records already exist will prompt to consolidate them. Confirming will delete the extra app policies. The delete operation cannot be undone.\n\nTurning it off will have the effect of creating multiple policies for each version. The number of extra policies is limited by the preference for number of apps to keep.\n\nFor line-of-business (LOB) apps, if the app is assigned with Required intent and the admin updates the app content, installation is attempted at the next device check-in. If installation fails, Intune retries every 24 hours.\n\nWhen you upload a new version of an available app to Intune, users must select Install or Reinstall in Company Portal to update the app on their device.\n")
+
+        // Add custom styling for the rest of the text
+        helpText.addAttributes([
+            .foregroundColor: NSColor.textColor,
+            .font: NSFont.systemFont(ofSize: 13)
+        ], range: NSRange(location: 0, length: helpText.length))
+
+        // Show the popover
+        helpPopover.showHelp(anchorView: sender, helpText: helpText)
+    }
+
     /// Displays help about the "App Display Name" field.
     /// Shows a popover explaining how the display name  is used in Intune and  Company Portal.
     /// - Parameter sender: The help button that was clicked.

--- a/Intuneomator/ViewControllers/EditViewController+MetadataLoad.swift
+++ b/Intuneomator/ViewControllers/EditViewController+MetadataLoad.swift
@@ -58,7 +58,12 @@ extension EditViewController {
         if appMetadata?.isCliPKG == nil {
             appMetadata?.isCliPKG = false
         }
-        
+
+        // Set a value for metadata saved in older versions pre this key
+        if appMetadata?.useSingleAppPolicy == nil {
+            appMetadata?.useSingleAppPolicy = false
+        }
+
         populateFieldsFromAppMetadata()
         
         let developer = appMetadata?.developer ?? ""
@@ -107,6 +112,7 @@ extension EditViewController {
         buttonFeatureApp.state = .off
         buttonManagedApp.state = .off
         buttonCliPkg.state = .off
+        buttonSingleAppPolicy.state = .off
         buttonDeploymentType.selectItem(withTag: 0)
         
         // Set default categories
@@ -127,6 +133,7 @@ extension EditViewController {
             isCliPKG: false,
             isFeatured: false,
             isManaged: false,
+            useSingleAppPolicy: false,
             minimumOS: "v13_0",
             minimumOSDisplay: "macOS Ventura 13.0",
             notes: "",

--- a/Intuneomator/ViewControllers/EditViewController+MetadataSave.swift
+++ b/Intuneomator/ViewControllers/EditViewController+MetadataSave.swift
@@ -71,6 +71,7 @@ extension EditViewController: TabSaveable {
             isCliPKG: (buttonCliPkg.state == .on),
             isFeatured: (buttonFeatureApp.state == .on),
             isManaged: (buttonManagedApp.state == .on),
+            useSingleAppPolicy: (buttonSingleAppPolicy.state == .on),
             minimumOS: getSelectedMinimumOsID() ?? "",
             minimumOSDisplay: buttonPopUpMinimumOs.selectedItem?.title ?? "",
             notes: partialNotes,

--- a/Intuneomator/ViewControllers/EditViewController+SingleAppPolicy.swift
+++ b/Intuneomator/ViewControllers/EditViewController+SingleAppPolicy.swift
@@ -1,0 +1,104 @@
+///
+///  EditViewController+SingleAppPolicy.swift
+///  Intuneomator
+///
+///  Extension for `EditViewController` to manage the "single app policy" toggle.
+///  Enabling this option reuses a single Intune app record across versions instead of
+///  creating a new one for every version. Since Intuneomator previously always created a
+///  new record per version, a title may already have multiple existing Intune records by
+///  the time this is switched on — turning it on triggers a two-step confirmed
+///  consolidation down to a single surviving record before the setting takes effect.
+///
+
+import Foundation
+import AppKit
+
+extension EditViewController {
+
+    /// Handles the "Single Policy" checkbox toggle.
+    /// Turning it ON may require consolidating existing duplicate Intune app records first;
+    /// turning it OFF is forward-looking only and needs no confirmation.
+    /// - Parameter sender: The checkbox that triggered this action.
+    @IBAction func buttonSingleAppPolicyDidChange(_ sender: NSButton) {
+        if sender.state == .on {
+            progSingleAppPolicy.startAnimation(self)
+            buttonSingleAppPolicy.isEnabled = false
+            handleSingleAppPolicyEnabled()
+        } else {
+            trackChanges()
+        }
+    }
+
+    /// Checks how many existing Intune app records exist for this title's tracking ID.
+    /// If 0 or 1, there's nothing to consolidate and the toggle is accepted immediately.
+    /// If more than 1, prompts for two-step confirmation before consolidating.
+    private func handleSingleAppPolicyEnabled() {
+        guard let appData = appData else { return }
+        let labelFolder = "\(appData.label)_\(appData.guid)"
+
+        XPCManager.shared.findAppsByTrackingID(appData.guid) { [weak self] apps in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                let existingCount = apps?.count ?? 0
+                if existingCount <= 1 {
+                    self.trackChanges()
+                } else {
+                    self.confirmAndConsolidate(labelFolder: labelFolder, existingCount: existingCount)
+                }
+                self.progSingleAppPolicy.stopAnimation(self)
+                self.buttonSingleAppPolicy.isEnabled = true
+            }
+        }
+    }
+
+    /// Shows the two-step "are you sure" confirmation for consolidating duplicate Intune app
+    /// records, mirroring the destructive-action pattern used by "Delete Automations from
+    /// Intune". On confirmation, calls the daemon to perform the consolidation.
+    private func confirmAndConsolidate(labelFolder: String, existingCount: Int) {
+        let alert = NSAlert()
+        alert.messageText = "Consolidate Existing Intune Records"
+        alert.informativeText = "This title currently has \(existingCount) app records in Intune. Enabling single-policy mode requires keeping only the newest record and deleting the other \(existingCount - 1). This cannot be undone."
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Consolidate")
+        alert.addButton(withTitle: "Cancel")
+
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            buttonSingleAppPolicy.state = .off
+            return
+        }
+
+        let confirmAlert = NSAlert()
+        confirmAlert.messageText = "Are you absolutely sure?"
+        confirmAlert.informativeText = "This action cannot be undone. \(existingCount - 1) older Intune app record(s) will be permanently deleted, keeping only the newest."
+        confirmAlert.alertStyle = .critical
+        confirmAlert.addButton(withTitle: "Really Delete")
+        confirmAlert.addButton(withTitle: "Cancel")
+
+        guard confirmAlert.runModal() == .alertFirstButtonReturn else {
+            buttonSingleAppPolicy.state = .off
+            return
+        }
+
+        buttonSingleAppPolicy.isEnabled = false
+        XPCManager.shared.consolidateToSingleAppPolicy(labelFolder) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                self.buttonSingleAppPolicy.isEnabled = true
+
+                let success = result?["success"] as? Bool ?? false
+                if success {
+                    self.trackChanges()
+                } else {
+                    self.buttonSingleAppPolicy.state = .off
+                    let message = result?["message"] as? String ?? "Unknown error"
+                    let failAlert = NSAlert()
+                    failAlert.messageText = "Consolidation Failed"
+                    failAlert.informativeText = message
+                    failAlert.alertStyle = .critical
+                    failAlert.runModal()
+                }
+            }
+        }
+    }
+
+}

--- a/Intuneomator/ViewControllers/EditViewController+TrackChanges.swift
+++ b/Intuneomator/ViewControllers/EditViewController+TrackChanges.swift
@@ -54,6 +54,7 @@ extension EditViewController {
             isCliPKG: (buttonCliPkg.state == .on),
             isFeatured: (buttonFeatureApp.state == .on),
             isManaged: (buttonManagedApp.state == .on),
+            useSingleAppPolicy: (buttonSingleAppPolicy.state == .on),
             minimumOS: getSelectedMinimumOsID() ?? "",
             minimumOSDisplay: buttonPopUpMinimumOs.selectedItem?.title ?? "",
             notes: notes,
@@ -158,6 +159,12 @@ extension EditViewController {
             hasUnsavedChanges = true
         }
 
+        // Highlight if useSingleAppPolicy is not its default value
+        if currentMetadata.useSingleAppPolicy != false { // Assume false as default
+            highlightField(buttonSingleAppPolicy)
+            hasUnsavedChanges = true
+        }
+
         // Highlight the description field
         if !currentMetadata.description.isEmpty {
             setTextViewBorder(field: fieldLabelDescription, color: NSColor.systemYellow)
@@ -191,6 +198,7 @@ extension EditViewController {
         buttonCliPkg.layer?.backgroundColor = nil
         buttonFeatureApp.layer?.backgroundColor = nil
         buttonManagedApp.layer?.backgroundColor = nil
+        buttonSingleAppPolicy.layer?.backgroundColor = nil
         buttonDeploymentType.layer?.backgroundColor = nil
         setTextViewBorder(field: fieldLabelDescription, color: NSColor.clear)
         clearHighlight(buttonEditOther)
@@ -289,7 +297,14 @@ extension EditViewController {
         } else {
             clearHighlight(buttonManagedApp)
         }
-        
+
+        // Check Single App Policy
+        if currentMetadata.useSingleAppPolicy != lastMetadata.useSingleAppPolicy {
+            highlightField(buttonSingleAppPolicy)
+        } else {
+            clearHighlight(buttonSingleAppPolicy)
+        }
+
 
         // Check description
         if currentMetadata.description != lastMetadata.description {

--- a/Intuneomator/ViewControllers/EditViewController.swift
+++ b/Intuneomator/ViewControllers/EditViewController.swift
@@ -31,6 +31,12 @@ import UniformTypeIdentifiers
 /// It manages UI interactions, metadata loading/saving, inspection workflows, and change tracking.
 class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextStorageDelegate, Configurable, UnsavedChangesHandling, EditOtherViewControllerDelegate {
     
+    /// Checkbox to reuse a single Intune app record across versions instead of creating a new one each time.
+    @IBOutlet weak var buttonSingleAppPolicy: NSButton!
+
+    /// Progress indicator for changing the automation to a single Intune app policy.
+    @IBOutlet weak var progSingleAppPolicy: NSProgressIndicator!
+
     /// Progress indicator for package inspection/download tasks.
     @IBOutlet weak var progPkgInspect: NSProgressIndicator!
 
@@ -391,6 +397,7 @@ class EditViewController: NSViewController, URLSessionDownloadDelegate, NSTextSt
         buttonCliPkg.state = appMetadata?.isCliPKG ?? false ? .on : .off
         buttonFeatureApp.state = appMetadata?.isFeatured ?? false ? .on : .off
         buttonManagedApp.state = appMetadata?.isManaged ?? false ? .on : .off
+        buttonSingleAppPolicy.state = appMetadata?.useSingleAppPolicy ?? false ? .on : .off
         radioYes.state = appMetadata?.ignoreVersionDetection ?? false ? .on : .off
         radioNo.state = appMetadata?.ignoreVersionDetection ?? true ? .off : .on
         

--- a/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
+++ b/Intuneomator/XPCManager/XPCManager+ViewCalls.swift
@@ -84,7 +84,17 @@ extension XPCManager {
     func findAppsByTrackingID(_ trackingID: String, completion: @escaping ([[String: Any]]?) -> Void) {
         sendRequest({ $0.findAppsByTrackingID(trackingID: trackingID, reply: $1) }, completion: completion)
     }
-    
+
+    /// Consolidates all existing Intune app records for a label folder's tracking ID down to
+    /// a single survivor (newest by createdDateTime), deleting the rest. Destructive — caller
+    /// must have already obtained user confirmation.
+    /// - Parameters:
+    ///   - labelFolder: Target label folder name (format "label_GUID")
+    ///   - completion: Callback with a result dictionary ("survivorAppId", "deletedCount", "success", "message") or nil on XPC failure
+    func consolidateToSingleAppPolicy(_ labelFolder: String, completion: @escaping ([String: Any]?) -> Void) {
+        sendRequest({ $0.consolidateToSingleAppPolicy(labelFolder, reply: $1) }, completion: completion)
+    }
+
     // MARK: - Label Content Management
     
     /// Creates a new managed label folder with initial content and metadata

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Upload.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+Upload.swift
@@ -22,22 +22,24 @@ extension EntraGraphRequests {
     ///   - authToken: OAuth bearer token for Microsoft Graph authentication
     ///   - app: ProcessedAppResults containing application data and configuration
     ///   - operationId: Optional operation ID for upload progress tracking
+    ///   - existingAppId: When non-nil, reuse this existing Intune app record (patch its content
+    ///     version and version metadata in place) instead of creating a new app record
     /// - Returns: The unique identifier of the uploaded application in Intune
     /// - Throws: Upload errors, authentication errors, or unsupported file type errors
-    static func uploadAppToIntune(authToken: String, app: ProcessedAppResults, operationId: String? = nil) async throws -> String {
+    static func uploadAppToIntune(authToken: String, app: ProcessedAppResults, operationId: String? = nil, existingAppId: String? = nil) async throws -> String {
         Logger.info("🖥️  Uploading app to Intune...", category: .core)
         let uploadedAppID: String
-        
+
         // Route to appropriate upload method based on deployment type
         if app.appDeploymentType == 2 {
             Logger.info("Deploying LOB app...", category: .core)
-            uploadedAppID = try await uploadLOBPkg(authToken: authToken, app: app, operationId: operationId)
+            uploadedAppID = try await uploadLOBPkg(authToken: authToken, app: app, operationId: operationId, existingAppId: existingAppId)
         } else if app.appDeploymentType == 1 {
             Logger.info("Deploying PKG app...", category: .core)
-            uploadedAppID = try await uploadPKGWithScripts(authToken: authToken, app: app, operationId: operationId)
+            uploadedAppID = try await uploadPKGWithScripts(authToken: authToken, app: app, operationId: operationId, existingAppId: existingAppId)
         } else if app.appDeploymentType == 0 {
             Logger.info("Deploying DMG app...", category: .core)
-            uploadedAppID = try await uploadDMGApp(authToken: authToken, app: app, operationId: operationId)
+            uploadedAppID = try await uploadDMGApp(authToken: authToken, app: app, operationId: operationId, existingAppId: existingAppId)
         } else {
             throw NSError(domain: "UnsupportedFileType", code: 1, userInfo: [NSLocalizedDescriptionKey: "Unsupported file type for upload."])
         }

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadDMG.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadDMG.swift
@@ -21,16 +21,11 @@ extension EntraGraphRequests {
     /// - Parameters:
     ///   - authToken: OAuth bearer token for Microsoft Graph authentication
     ///   - app: ProcessedAppResults containing all application data and configuration
+    ///   - existingAppId: When non-nil, reuse this existing Intune DMG app record (patch its
+    ///     content version and version metadata in place) instead of creating a new app record
     /// - Returns: The unique identifier of the uploaded DMG application in Intune
     /// - Throws: Upload errors, encryption errors, network errors, or API errors
-    static func uploadDMGApp(authToken: String, app: ProcessedAppResults, operationId: String? = nil) async throws -> String {
-        // Step 1: Create application metadata in Intune
-        let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
-        var request = URLRequest(url: metadataURL)
-        request.httpMethod = "POST"
-        request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+    static func uploadDMGApp(authToken: String, app: ProcessedAppResults, operationId: String? = nil, existingAppId: String? = nil) async throws -> String {
         // Build comprehensive notes field with Intuneomator tracking ID
         let fullNotes: String
         if app.appNotes.isEmpty {
@@ -44,81 +39,96 @@ extension EntraGraphRequests {
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
         let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
 
-        // Construct comprehensive DMG application metadata
-        var metadata: [String: Any] = [
-            "@odata.type": "#microsoft.graph.macOSDmgApp",
-            "displayName": displayName,
-            "description": app.appDescription,
-            "developer": app.appDeveloper,
-            "publisher": app.appPublisherName,
-            "owner": app.appOwner,
-            "notes": fullNotes,
-            "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
-            "privacyInformationUrl": app.appPrivacyPolicyURL,
-            "informationUrl": app.appInfoURL,
-            "primaryBundleId": app.appBundleIdActual,
-            "primaryBundleVersion": app.appVersionActual,
-            "ignoreVersionDetection": app.appIgnoreVersion,
-            "isFeatured": app.appIsFeatured,
-            "includedApps": [[
-                "@odata.type": "#microsoft.graph.macOSIncludedApp",
-                "bundleId": app.appBundleIdActual,
-                "bundleVersion": app.appVersionActual
-            ]]
-        ]
-        
-        // Add minimum macOS version requirements
-        metadata["minimumSupportedOperatingSystem"] = [
-            "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
-            "v10_13": app.appMinimumOS.contains("v10_13"),
-            "v10_14": app.appMinimumOS.contains("v10_14"),
-            "v10_15": app.appMinimumOS.contains("v10_15"),
-            "v11_0": app.appMinimumOS.contains("v11_0"),
-            "v12_0": app.appMinimumOS.contains("v12_0"),
-            "v13_0": app.appMinimumOS.contains("v13_0"),
-            "v14_0": app.appMinimumOS.contains("v14_0"),
-            "v15_0": app.appMinimumOS.contains("v15_0"),
-            "v26_0": app.appMinimumOS.contains("v26_0")
-        ]
-        
-        // Include application icon if available
-        if FileManager.default.fileExists(atPath: app.appIconURL),
-           let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
-            metadata["largeIcon"] = [
-                "@odata.type": "#microsoft.graph.mimeContent",
-                "type": "image/png",
-                "value": iconData.base64EncodedString()
+        let appId: String
+        if let existingAppId {
+            // Reuse mode: skip creating a new app record entirely — the content version
+            // upload below (Steps 2-8) and the merged PATCH (Step 9) target this record.
+            appId = existingAppId
+            Logger.info("  ♻️ Reusing existing DMG app record. App ID: \(appId)", category: .core)
+        } else {
+            // Step 1: Create application metadata in Intune
+            let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
+            var request = URLRequest(url: metadataURL)
+            request.httpMethod = "POST"
+            request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            // Construct comprehensive DMG application metadata
+            var metadata: [String: Any] = [
+                "@odata.type": "#microsoft.graph.macOSDmgApp",
+                "displayName": displayName,
+                "description": app.appDescription,
+                "developer": app.appDeveloper,
+                "publisher": app.appPublisherName,
+                "owner": app.appOwner,
+                "notes": fullNotes,
+                "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
+                "privacyInformationUrl": app.appPrivacyPolicyURL,
+                "informationUrl": app.appInfoURL,
+                "primaryBundleId": app.appBundleIdActual,
+                "primaryBundleVersion": app.appVersionActual,
+                "ignoreVersionDetection": app.appIgnoreVersion,
+                "isFeatured": app.appIsFeatured,
+                "includedApps": [[
+                    "@odata.type": "#microsoft.graph.macOSIncludedApp",
+                    "bundleId": app.appBundleIdActual,
+                    "bundleVersion": app.appVersionActual
+                ]]
             ]
-        }
-        
-        request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
-        
-        // Create DMG application in Intune
-        let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
-        
-        if let httpResponse = metadataResponse as? HTTPURLResponse {
-            Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
-            if !(200...299).contains(httpResponse.statusCode) {
-                let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
-                Logger.error("Error response body: \(responseBody)", category: .core)
-                throw NSError(domain: "UploadDMGApp", code: httpResponse.statusCode, userInfo: [
-                    NSLocalizedDescriptionKey: "Failed to create DMG app metadata. Status: \(httpResponse.statusCode)"
+
+            // Add minimum macOS version requirements
+            metadata["minimumSupportedOperatingSystem"] = [
+                "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
+                "v10_13": app.appMinimumOS.contains("v10_13"),
+                "v10_14": app.appMinimumOS.contains("v10_14"),
+                "v10_15": app.appMinimumOS.contains("v10_15"),
+                "v11_0": app.appMinimumOS.contains("v11_0"),
+                "v12_0": app.appMinimumOS.contains("v12_0"),
+                "v13_0": app.appMinimumOS.contains("v13_0"),
+                "v14_0": app.appMinimumOS.contains("v14_0"),
+                "v15_0": app.appMinimumOS.contains("v15_0"),
+                "v26_0": app.appMinimumOS.contains("v26_0")
+            ]
+
+            // Include application icon if available
+            if FileManager.default.fileExists(atPath: app.appIconURL),
+               let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
+                metadata["largeIcon"] = [
+                    "@odata.type": "#microsoft.graph.mimeContent",
+                    "type": "image/png",
+                    "value": iconData.base64EncodedString()
+                ]
+            }
+
+            request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
+
+            // Create DMG application in Intune
+            let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = metadataResponse as? HTTPURLResponse {
+                Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
+                if !(200...299).contains(httpResponse.statusCode) {
+                    let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
+                    Logger.error("Error response body: \(responseBody)", category: .core)
+                    throw NSError(domain: "UploadDMGApp", code: httpResponse.statusCode, userInfo: [
+                        NSLocalizedDescriptionKey: "Failed to create DMG app metadata. Status: \(httpResponse.statusCode)"
+                    ])
+                }
+            }
+
+            guard let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any] else {
+                throw NSError(domain: "UploadDMGApp", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
+            }
+
+            guard let newAppId = metadataJson["id"] as? String else {
+                throw NSError(domain: "UploadDMGApp", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
                 ])
             }
+            appId = newAppId
+
+            Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
         }
-        
-        guard let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any] else {
-            throw NSError(domain: "UploadDMGApp", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
-        }
-        
-        guard let appId = metadataJson["id"] as? String else {
-            throw NSError(domain: "UploadDMGApp", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
-            ])
-        }
-        
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
 
         // Step 2: Begin file upload workflow
         do {
@@ -251,10 +261,24 @@ extension EntraGraphRequests {
             updateRequest.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
             updateRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
             
-            let patchData = try JSONSerialization.data(withJSONObject: [
+            var patchBody: [String: Any] = [
                 "@odata.type": "#microsoft.graph.macOSDmgApp",
                 "committedContentVersion": versionId
-            ])
+            ]
+            if existingAppId != nil {
+                // Reuse mode: fold the version-carrying fields into this same PATCH so the
+                // existing record's displayed version, primaryBundleVersion, and includedApps
+                // bundleVersion advance to match the newly committed content version.
+                patchBody["displayName"] = displayName
+                patchBody["fileName"] = "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)"
+                patchBody["primaryBundleVersion"] = app.appVersionActual
+                patchBody["includedApps"] = [[
+                    "@odata.type": "#microsoft.graph.macOSIncludedApp",
+                    "bundleId": app.appBundleIdActual,
+                    "bundleVersion": app.appVersionActual
+                ]]
+            }
+            let patchData = try JSONSerialization.data(withJSONObject: patchBody)
             updateRequest.httpBody = patchData
             
             let (updateResponseData, updateResponse) = try await URLSession.shared.data(for: updateRequest)

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadLOB.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadLOB.swift
@@ -22,17 +22,12 @@ extension EntraGraphRequests {
     ///   - authToken: OAuth bearer token for Microsoft Graph authentication
     ///   - app: ProcessedAppResults containing all application data and configuration
     ///   - operationId: Optional operation ID for upload progress tracking
+    ///   - existingAppId: When non-nil, reuse this existing Intune LOB app record (patch its
+    ///     content version and version metadata in place) instead of creating a new app record
     /// - Returns: The unique identifier of the uploaded LOB application in Intune
     /// - Throws: Upload errors, encryption errors, network errors, or API errors
-    static func uploadLOBPkg(authToken: String, app: ProcessedAppResults, operationId: String? = nil) async throws -> String {
-        
-        // Step 1: Create LOB application metadata in Intune
-        let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
-        var request = URLRequest(url: metadataURL)
-        request.httpMethod = "POST"
-        request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+    static func uploadLOBPkg(authToken: String, app: ProcessedAppResults, operationId: String? = nil, existingAppId: String? = nil) async throws -> String {
+
         // Build comprehensive notes field with Intuneomator tracking ID
         let fullNotes: String
         if app.appNotes.isEmpty {
@@ -45,87 +40,102 @@ extension EntraGraphRequests {
         let fileName = URL(fileURLWithPath: app.appLocalURL).lastPathComponent
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
         let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
-        
-        // Construct comprehensive LOB application metadata
-        var metadata: [String: Any] = [
-            "@odata.type": "#microsoft.graph.macOSLobApp",
-            "displayName": displayName,
-            "description": app.appDescription,
-            "developer": app.appDeveloper,
-            "publisher": app.appPublisherName,
-            "owner": app.appOwner,
-            "notes": fullNotes,
-            "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
-            "privacyInformationUrl": app.appPrivacyPolicyURL,
-            "informationUrl": app.appInfoURL,
-            "primaryBundleId": app.appBundleIdActual,
-            "primaryBundleVersion": app.appVersionActual,
-            "ignoreVersionDetection": app.appIgnoreVersion,
-            "installAsManaged": app.appIsManaged,
-            "isFeatured": app.appIsFeatured,
-            "bundleId": app.appBundleIdActual,
-            "buildNumber": app.appVersionActual,
-            "minimumSupportedOperatingSystem": [
-                "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
-                "v10_13": app.appMinimumOS.contains("v10_13"),
-                "v10_14": app.appMinimumOS.contains("v10_14"),
-                "v10_15": app.appMinimumOS.contains("v10_15"),
-                "v11_0": app.appMinimumOS.contains("v11_0"),
-                "v12_0": app.appMinimumOS.contains("v12_0"),
-                "v13_0": app.appMinimumOS.contains("v13_0"),
-                "v14_0": app.appMinimumOS.contains("v14_0"),
-                "v15_0": app.appMinimumOS.contains("v15_0"),
-                "v26_0": app.appMinimumOS.contains("v26_0")
-            ],
-            "childApps": [[
-                "@odata.type": "#microsoft.graph.macOSLobChildApp",
+
+        let appId: String
+        if let existingAppId {
+            // Reuse mode: skip creating a new app record entirely — the content version
+            // upload below (Steps 2-8) and the merged PATCH (Step 9) target this record.
+            appId = existingAppId
+            Logger.info("  ♻️ Reusing existing LOB app record. App ID: \(appId)", category: .core)
+        } else {
+            // Step 1: Create LOB application metadata in Intune
+            let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
+            var request = URLRequest(url: metadataURL)
+            request.httpMethod = "POST"
+            request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            // Construct comprehensive LOB application metadata
+            var metadata: [String: Any] = [
+                "@odata.type": "#microsoft.graph.macOSLobApp",
+                "displayName": displayName,
+                "description": app.appDescription,
+                "developer": app.appDeveloper,
+                "publisher": app.appPublisherName,
+                "owner": app.appOwner,
+                "notes": fullNotes,
+                "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
+                "privacyInformationUrl": app.appPrivacyPolicyURL,
+                "informationUrl": app.appInfoURL,
+                "primaryBundleId": app.appBundleIdActual,
+                "primaryBundleVersion": app.appVersionActual,
+                "ignoreVersionDetection": app.appIgnoreVersion,
+                "installAsManaged": app.appIsManaged,
+                "isFeatured": app.appIsFeatured,
                 "bundleId": app.appBundleIdActual,
                 "buildNumber": app.appVersionActual,
-                "versionNumber": "0.0"
-            ]]
-        ]
-        
-        // Include application icon if available
-        if FileManager.default.fileExists(atPath: app.appIconURL),
-           let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
-            let base64Icon = iconData.base64EncodedString()
-            metadata["largeIcon"] = [
-                "@odata.type": "#microsoft.graph.mimeContent",
-                "type": "image/png",
-                "value": base64Icon
+                "minimumSupportedOperatingSystem": [
+                    "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
+                    "v10_13": app.appMinimumOS.contains("v10_13"),
+                    "v10_14": app.appMinimumOS.contains("v10_14"),
+                    "v10_15": app.appMinimumOS.contains("v10_15"),
+                    "v11_0": app.appMinimumOS.contains("v11_0"),
+                    "v12_0": app.appMinimumOS.contains("v12_0"),
+                    "v13_0": app.appMinimumOS.contains("v13_0"),
+                    "v14_0": app.appMinimumOS.contains("v14_0"),
+                    "v15_0": app.appMinimumOS.contains("v15_0"),
+                    "v26_0": app.appMinimumOS.contains("v26_0")
+                ],
+                "childApps": [[
+                    "@odata.type": "#microsoft.graph.macOSLobChildApp",
+                    "bundleId": app.appBundleIdActual,
+                    "buildNumber": app.appVersionActual,
+                    "versionNumber": "0.0"
+                ]]
             ]
-        }
-        
-        request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
-        
-        // Create LOB application in Intune
-        let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
-        
-        if let httpResponse = metadataResponse as? HTTPURLResponse {
-            Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
-            if !(200...299).contains(httpResponse.statusCode) {
-                let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
-                Logger.error("Error response body: \(responseBody)", category: .core)
-                throw NSError(domain: "UploadLOBPkg", code: httpResponse.statusCode, userInfo: [
-                    NSLocalizedDescriptionKey: "Failed to create LOB app metadata. Status: \(httpResponse.statusCode)"
+
+            // Include application icon if available
+            if FileManager.default.fileExists(atPath: app.appIconURL),
+               let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
+                let base64Icon = iconData.base64EncodedString()
+                metadata["largeIcon"] = [
+                    "@odata.type": "#microsoft.graph.mimeContent",
+                    "type": "image/png",
+                    "value": base64Icon
+                ]
+            }
+
+            request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
+
+            // Create LOB application in Intune
+            let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = metadataResponse as? HTTPURLResponse {
+                Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
+                if !(200...299).contains(httpResponse.statusCode) {
+                    let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
+                    Logger.error("Error response body: \(responseBody)", category: .core)
+                    throw NSError(domain: "UploadLOBPkg", code: httpResponse.statusCode, userInfo: [
+                        NSLocalizedDescriptionKey: "Failed to create LOB app metadata. Status: \(httpResponse.statusCode)"
+                    ])
+                }
+            }
+
+            guard
+                let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any]
+            else {
+                throw NSError(domain: "UploadLOBPkg", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
+            }
+
+            guard let newAppId = metadataJson["id"] as? String else {
+                throw NSError(domain: "UploadLOBPkg", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
                 ])
             }
+            appId = newAppId
+
+            Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
         }
-        
-        guard
-            let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any]
-        else {
-            throw NSError(domain: "UploadLOBPkg", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
-        }
-        
-        guard let appId = metadataJson["id"] as? String else {
-            throw NSError(domain: "UploadLOBPkg", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
-            ])
-        }
-        
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
 
         // Step 2: Begin file upload workflow
         do {
@@ -262,10 +272,26 @@ extension EntraGraphRequests {
             updateRequest.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
             updateRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
             
-            let patchData = try JSONSerialization.data(withJSONObject: [
+            var patchBody: [String: Any] = [
                 "@odata.type": "#microsoft.graph.macOSLobApp",
                 "committedContentVersion": versionId
-            ])
+            ]
+            if existingAppId != nil {
+                // Reuse mode: fold the version-carrying fields into this same PATCH so the
+                // existing record's displayed version, primaryBundleVersion, and childApps
+                // buildNumber advance to match the newly committed content version.
+                patchBody["displayName"] = displayName
+                patchBody["fileName"] = "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)"
+                patchBody["primaryBundleVersion"] = app.appVersionActual
+                patchBody["buildNumber"] = app.appVersionActual
+                patchBody["childApps"] = [[
+                    "@odata.type": "#microsoft.graph.macOSLobChildApp",
+                    "bundleId": app.appBundleIdActual,
+                    "buildNumber": app.appVersionActual,
+                    "versionNumber": "0.0"
+                ]]
+            }
+            let patchData = try JSONSerialization.data(withJSONObject: patchBody)
             updateRequest.httpBody = patchData
             
             let (updateResponseData, updateResponse) = try await URLSession.shared.data(for: updateRequest)

--- a/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadPKG.swift
+++ b/IntuneomatorService/EntraGraphRequests/EntraGraphRequests+UploadPKG.swift
@@ -21,16 +21,11 @@ extension EntraGraphRequests {
     /// - Parameters:
     ///   - authToken: OAuth bearer token for Microsoft Graph authentication
     ///   - app: ProcessedAppResults containing all application data, scripts, and configuration
+    ///   - existingAppId: When non-nil, reuse this existing Intune PKG app record (patch its
+    ///     content version and version metadata in place) instead of creating a new app record
     /// - Returns: The unique identifier of the uploaded PKG application in Intune
     /// - Throws: Upload errors, encryption errors, network errors, or API errors
-    static func uploadPKGWithScripts(authToken: String, app: ProcessedAppResults, operationId: String? = nil) async throws -> String {
-        // Step 1: Create PKG application metadata in Intune
-        let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
-        var request = URLRequest(url: metadataURL)
-        request.httpMethod = "POST"
-        request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        
+    static func uploadPKGWithScripts(authToken: String, app: ProcessedAppResults, operationId: String? = nil, existingAppId: String? = nil) async throws -> String {
         // Build comprehensive notes field with Intuneomator tracking ID
         let fullNotes: String
         if app.appNotes.isEmpty {
@@ -44,101 +39,116 @@ extension EntraGraphRequests {
         let arch = ["arm64", "x86_64"].first { fileName.contains($0) }
         let displayName = "\(app.appIntuneDisplayName) \(app.appVersionActual)\(arch.map { " \($0)" } ?? "")"
 
-        // Construct comprehensive PKG application metadata
-        var metadata: [String: Any] = [
-            "@odata.type": "#microsoft.graph.macOSPkgApp",
-            "displayName": displayName,
-            "description": app.appDescription,
-            "developer": app.appPublisherName,
-            "publisher": app.appPublisherName,
-            "owner": app.appOwner,
-            "notes": fullNotes,
-            "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
-            "privacyInformationUrl": "",
-            "informationUrl": app.appInfoURL,
-            "primaryBundleId": app.appBundleIdActual,
-            "primaryBundleVersion": app.appVersionActual,
-            "ignoreVersionDetection": app.appIgnoreVersion,
-            "isFeatured": app.appIsFeatured,
-            "bundleId": app.appBundleIdActual,
-            "buildNumber": app.appVersionActual,
-            "includedApps": [[
-                "@odata.type": "#microsoft.graph.macOSIncludedApp",
+        let appId: String
+        if let existingAppId {
+            // Reuse mode: skip creating a new app record entirely — the content version
+            // upload below (Steps 2-8) and the merged PATCH (Step 9) target this record.
+            appId = existingAppId
+            Logger.info("  ♻️ Reusing existing PKG app record. App ID: \(appId)", category: .core)
+        } else {
+            // Step 1: Create PKG application metadata in Intune
+            let metadataURL = URL(string: "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps")!
+            var request = URLRequest(url: metadataURL)
+            request.httpMethod = "POST"
+            request.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            // Construct comprehensive PKG application metadata
+            var metadata: [String: Any] = [
+                "@odata.type": "#microsoft.graph.macOSPkgApp",
+                "displayName": displayName,
+                "description": app.appDescription,
+                "developer": app.appPublisherName,
+                "publisher": app.appPublisherName,
+                "owner": app.appOwner,
+                "notes": fullNotes,
+                "fileName": "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)",
+                "privacyInformationUrl": "",
+                "informationUrl": app.appInfoURL,
+                "primaryBundleId": app.appBundleIdActual,
+                "primaryBundleVersion": app.appVersionActual,
+                "ignoreVersionDetection": app.appIgnoreVersion,
+                "isFeatured": app.appIsFeatured,
                 "bundleId": app.appBundleIdActual,
-                "bundleVersion": app.appVersionActual
-            ]]
-        ]
-        
-        // Add pre-install script if provided (Base64 encoded for secure transmission)
-        let preInstall = app.appScriptPreInstall
-        if !preInstall.isEmpty {
-            metadata["preInstallScript"] = [
-                "@odata.type": "#microsoft.graph.macOSAppScript",
-                "scriptContent": Data(preInstall.utf8).base64EncodedString()
+                "buildNumber": app.appVersionActual,
+                "includedApps": [[
+                    "@odata.type": "#microsoft.graph.macOSIncludedApp",
+                    "bundleId": app.appBundleIdActual,
+                    "bundleVersion": app.appVersionActual
+                ]]
             ]
-        }
-        
-        // Add post-install script if provided (Base64 encoded for secure transmission)
-        let postInstall = app.appScriptPostInstall
-        if !postInstall.isEmpty {
-            metadata["postInstallScript"] = [
-                "@odata.type": "#microsoft.graph.macOSAppScript",
-                "scriptContent": Data(postInstall.utf8).base64EncodedString()
+
+            // Add pre-install script if provided (Base64 encoded for secure transmission)
+            let preInstall = app.appScriptPreInstall
+            if !preInstall.isEmpty {
+                metadata["preInstallScript"] = [
+                    "@odata.type": "#microsoft.graph.macOSAppScript",
+                    "scriptContent": Data(preInstall.utf8).base64EncodedString()
+                ]
+            }
+
+            // Add post-install script if provided (Base64 encoded for secure transmission)
+            let postInstall = app.appScriptPostInstall
+            if !postInstall.isEmpty {
+                metadata["postInstallScript"] = [
+                    "@odata.type": "#microsoft.graph.macOSAppScript",
+                    "scriptContent": Data(postInstall.utf8).base64EncodedString()
+                ]
+            }
+
+            // Add minimum macOS version requirements
+            metadata["minimumSupportedOperatingSystem"] = [
+                "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
+                "v10_13": app.appMinimumOS.contains("v10_13"),
+                "v10_14": app.appMinimumOS.contains("v10_14"),
+                "v10_15": app.appMinimumOS.contains("v10_15"),
+                "v11_0": app.appMinimumOS.contains("v11_0"),
+                "v12_0": app.appMinimumOS.contains("v12_0"),
+                "v13_0": app.appMinimumOS.contains("v13_0"),
+                "v14_0": app.appMinimumOS.contains("v14_0"),
+                "v15_0": app.appMinimumOS.contains("v15_0"),
+                "v26_0": app.appMinimumOS.contains("v26_0")
             ]
-        }
-        
-        // Add minimum macOS version requirements
-        metadata["minimumSupportedOperatingSystem"] = [
-            "@odata.type": "#microsoft.graph.macOSMinimumOperatingSystem",
-            "v10_13": app.appMinimumOS.contains("v10_13"),
-            "v10_14": app.appMinimumOS.contains("v10_14"),
-            "v10_15": app.appMinimumOS.contains("v10_15"),
-            "v11_0": app.appMinimumOS.contains("v11_0"),
-            "v12_0": app.appMinimumOS.contains("v12_0"),
-            "v13_0": app.appMinimumOS.contains("v13_0"),
-            "v14_0": app.appMinimumOS.contains("v14_0"),
-            "v15_0": app.appMinimumOS.contains("v15_0"),
-            "v26_0": app.appMinimumOS.contains("v26_0")
-        ]
-        
-        // Include application icon if available
-        if FileManager.default.fileExists(atPath: app.appIconURL),
-           let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
-            metadata["largeIcon"] = [
-                "@odata.type": "#microsoft.graph.mimeContent",
-                "type": "image/png",
-                "value": iconData.base64EncodedString()
-            ]
-        }
-        
-        request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
-        
-        // Create PKG application in Intune
-        let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
-        
-        if let httpResponse = metadataResponse as? HTTPURLResponse {
-            Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
-            if !(200...299).contains(httpResponse.statusCode) {
-                let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
-                Logger.error("Error response body: \(responseBody)", category: .core)
-                throw NSError(domain: "UploadPKGWithScripts", code: httpResponse.statusCode, userInfo: [
-                    NSLocalizedDescriptionKey: "Failed to create PKG app metadata. Status: \(httpResponse.statusCode)"
+
+            // Include application icon if available
+            if FileManager.default.fileExists(atPath: app.appIconURL),
+               let iconData = try? Data(contentsOf: URL(fileURLWithPath: app.appIconURL)) {
+                metadata["largeIcon"] = [
+                    "@odata.type": "#microsoft.graph.mimeContent",
+                    "type": "image/png",
+                    "value": iconData.base64EncodedString()
+                ]
+            }
+
+            request.httpBody = try JSONSerialization.data(withJSONObject: metadata, options: [])
+
+            // Create PKG application in Intune
+            let (metadataData, metadataResponse) = try await URLSession.shared.data(for: request)
+
+            if let httpResponse = metadataResponse as? HTTPURLResponse {
+                Logger.info("Metadata response status code: \(httpResponse.statusCode)", category: .core)
+                if !(200...299).contains(httpResponse.statusCode) {
+                    let responseBody = String(data: metadataData, encoding: .utf8) ?? "<non-UTF8 data>"
+                    Logger.error("Error response body: \(responseBody)", category: .core)
+                    throw NSError(domain: "UploadPKGWithScripts", code: httpResponse.statusCode, userInfo: [
+                        NSLocalizedDescriptionKey: "Failed to create PKG app metadata. Status: \(httpResponse.statusCode)"
+                    ])
+                }
+            }
+
+            guard let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any] else {
+                throw NSError(domain: "UploadPKGWithScripts", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
+            }
+
+            guard let newAppId = metadataJson["id"] as? String else {
+                throw NSError(domain: "UploadPKGWithScripts", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
                 ])
             }
+            appId = newAppId
+
+            Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
         }
-        
-        guard let metadataJson = try JSONSerialization.jsonObject(with: metadataData) as? [String: Any] else {
-            throw NSError(domain: "UploadPKGWithScripts", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid JSON returned from metadata request."])
-        }
-        
-        guard let appId = metadataJson["id"] as? String else {
-            throw NSError(domain: "UploadPKGWithScripts", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "Failed to parse app ID from response: \(metadataJson)"
-            ])
-        }
-        
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
-        Logger.info("  ⬆️ Uploaded \(displayName) metadata. App ID: \(appId)", category: .core)
 
         // Step 2: Begin file upload workflow
         do {
@@ -271,10 +281,25 @@ extension EntraGraphRequests {
             updateRequest.addValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
             updateRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
             
-            let patchData = try JSONSerialization.data(withJSONObject: [
+            var patchBody: [String: Any] = [
                 "@odata.type": "#microsoft.graph.macOSPkgApp",
                 "committedContentVersion": versionId
-            ])
+            ]
+            if existingAppId != nil {
+                // Reuse mode: fold the version-carrying fields into this same PATCH so the
+                // existing record's displayed version, primaryBundleVersion, and includedApps
+                // bundleVersion advance to match the newly committed content version.
+                patchBody["displayName"] = displayName
+                patchBody["fileName"] = "\(URL(fileURLWithPath: app.appLocalURL).lastPathComponent)"
+                patchBody["primaryBundleVersion"] = app.appVersionActual
+                patchBody["buildNumber"] = app.appVersionActual
+                patchBody["includedApps"] = [[
+                    "@odata.type": "#microsoft.graph.macOSIncludedApp",
+                    "bundleId": app.appBundleIdActual,
+                    "bundleVersion": app.appVersionActual
+                ]]
+            }
+            let patchData = try JSONSerialization.data(withJSONObject: patchBody)
             updateRequest.httpBody = patchData
             
             let (updateResponseData, updateResponse) = try await URLSession.shared.data(for: updateRequest)

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ConsolidateAppPolicy.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ConsolidateAppPolicy.swift
@@ -1,0 +1,124 @@
+//
+//  LabelAutomation+ConsolidateAppPolicy.swift
+//  Intuneomator
+//
+//  Created by Gil Burns on 8/15/26.
+//
+
+import Foundation
+
+// MARK: - Single App Policy Consolidation Extension
+
+/// Extension for handling consolidation of duplicate Intune app records down to a single
+/// surviving record, in support of "single app policy" mode (reuse the same Intune app
+/// record across versions instead of creating a new one each run).
+extension LabelAutomation {
+
+    // MARK: - Consolidate to Single App Policy
+
+    /// Consolidates all existing Intune app records matching a label folder's tracking ID
+    /// down to a single survivor: the newest record by `createdDateTime`. All other matching
+    /// records are deleted, and the current local group assignments are reasserted on the
+    /// survivor to guarantee deployment continuity regardless of which record previously
+    /// carried the "live" assignments.
+    ///
+    /// Idempotent — safe to call when there are already 0 or 1 matching records; returns a
+    /// no-op success in that case.
+    ///
+    /// - Parameter folderName: The managed title folder name to process (format "label_GUID")
+    /// - Returns: Tuple containing the surviving app ID (if any), how many records were
+    ///   deleted, whether the operation fully succeeded, and a human-readable summary message
+    static func consolidateToSingleAppPolicy(named folderName: String) async
+        -> (survivorAppId: String?, deletedCount: Int, success: Bool, message: String) {
+
+        Logger.info("--------------------------------------------------------", category: .automation)
+        Logger.info("🚀 Start consolidation to single app policy for: \(folderName)", category: .automation)
+
+        guard let processedAppResults = extractDataForProcessedAppResults(from: folderName) else {
+            let message = "Failed to extract ProcessedAppResults data for \(folderName)"
+            Logger.error("  \(message)", category: .automation)
+            return (nil, 0, false, message)
+        }
+
+        let trackingID = processedAppResults.appTrackingID
+
+        // Determine the Intune app type string for this title's deployment type
+        let intuneAppType: String
+        switch processedAppResults.appDeploymentType {
+        case 0:
+            intuneAppType = "macOSDmgApp"
+        case 1:
+            intuneAppType = "macOSPkgApp"
+        case 2:
+            intuneAppType = "macOSLobApp"
+        default:
+            intuneAppType = "macOSLobApp"
+        }
+
+        do {
+            let entraAuthenticator = EntraAuthenticator.shared
+            let authToken = try await entraAuthenticator.getEntraIDToken()
+
+            let appInfo = try await EntraGraphRequests.findAppsByTrackingID(authToken: authToken, trackingID: trackingID)
+            Logger.info("    Found \(appInfo.count) apps matching tracking ID \(trackingID)", category: .automation)
+
+            guard appInfo.count > 1 else {
+                let message = "Nothing to consolidate — \(appInfo.count) record(s) found."
+                Logger.info("  \(message)", category: .automation)
+                return (appInfo.first?.id, 0, true, message)
+            }
+
+            // Newest by createdDateTime survives; the rest are deleted.
+            let sorted = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
+            let survivor = sorted.last!
+            let toDelete = sorted.dropLast()
+
+            Logger.info("  Survivor: \(survivor.displayName) (id: \(survivor.id), created: \(survivor.createdDateTime))", category: .automation)
+
+            var deletedCount = 0
+            var failedDeletes: [String] = []
+            for app in toDelete {
+                do {
+                    Logger.info("  Deleting duplicate app \(app.displayName) (id: \(app.id), created: \(app.createdDateTime))", category: .automation)
+                    try await EntraGraphRequests.deleteIntuneApp(authToken: authToken, appId: app.id)
+                    deletedCount += 1
+                } catch {
+                    Logger.error("  Failed to delete duplicate app \(app.id): \(error.localizedDescription)", category: .automation)
+                    failedDeletes.append(app.id)
+                }
+            }
+
+            // Reassign the survivor using the current local assignments, regardless of which
+            // of the N old records happened to carry the "live" assignments.
+            do {
+                try await EntraGraphRequests.assignGroupsToApp(
+                    authToken: authToken,
+                    appId: survivor.id,
+                    appAssignments: processedAppResults.appAssignments,
+                    appType: intuneAppType,
+                    installAsManaged: processedAppResults.appIsManaged
+                )
+            } catch {
+                let message = "Deleted \(deletedCount) duplicate record(s), but failed to reassign groups to the surviving record: \(error.localizedDescription)"
+                Logger.error("  \(message)", category: .automation)
+                return (survivor.id, deletedCount, false, message)
+            }
+
+            guard failedDeletes.isEmpty else {
+                let message = "Deleted \(deletedCount) of \(toDelete.count) duplicate record(s); failed to delete: \(failedDeletes.joined(separator: ", "))"
+                Logger.error("  \(message)", category: .automation)
+                return (survivor.id, deletedCount, false, message)
+            }
+
+            let message = "Consolidated to a single app policy. Deleted \(deletedCount) duplicate record(s)."
+            Logger.info("✅ \(message)", category: .automation)
+            return (survivor.id, deletedCount, true, message)
+
+        } catch {
+            let message = "Failed to fetch app info from Intune: \(error.localizedDescription)"
+            Logger.error("  \(message)", category: .automation)
+            return (nil, 0, false, message)
+        }
+    }
+
+}

--- a/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
+++ b/IntuneomatorService/LabelAutomation/LabelAutomation+ProcessFolder.swift
@@ -323,24 +323,31 @@ extension LabelAutomation {
                 Logger.info("  Folder cleanup: \(deleteFolder)", category: .automation)
                 
                 // Clean up extra older versions of the app (AppVersionsToKeep changed?)
-                do {
-                    let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
-                    let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
-                    let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
-                    if versionsToDeleteCount > 0 {
-                        let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
-                        for app in appsToDelete {
-                            guard !app.isAssigned else { continue }
-                            Logger.info("Deleting older app \(app.displayName)", category: .automation)
-                            Logger.info("Deleting older app \(app.primaryBundleVersion)", category: .automation)
-                            Logger.info("Deleting older app \(app.id)", category: .automation)
-                            try await EntraGraphRequests.deleteIntuneApp(authToken: authToken, appId: app.id)
+                // Skipped entirely in single-app-policy mode — deleting Intune records is a
+                // destructive action that must go through the GUI-confirmed consolidate flow,
+                // never silently as a side effect of an automated background run.
+                if !processedAppResults.appUseSingleAppPolicy {
+                    do {
+                        let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
+                        let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
+                        let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
+                        if versionsToDeleteCount > 0 {
+                            let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
+                            for app in appsToDelete {
+                                guard !app.isAssigned else { continue }
+                                Logger.info("Deleting older app \(app.displayName)", category: .automation)
+                                Logger.info("Deleting older app \(app.primaryBundleVersion)", category: .automation)
+                                Logger.info("Deleting older app \(app.id)", category: .automation)
+                                try await EntraGraphRequests.deleteIntuneApp(authToken: authToken, appId: app.id)
+                            }
                         }
+                    } catch {
+                        Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
                     }
-                } catch {
-                    Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
+                } else if appInfo.count > 1 {
+                    Logger.info("⚠️ Single-policy mode: \(appInfo.count) existing Intune records found for this title; use the GUI's consolidate action to trim to one.", category: .automation)
                 }
-                
+
                 let successMessage = "\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) already exists in Intune"
                 statusManager.failOperation(operationId: operationId, errorMessage: "Version \(processedAppResults.appVersionActual) already exists in Intune")
                 return (successMessage, processedAppResults.appIntuneDisplayName, "", true)
@@ -349,6 +356,17 @@ extension LabelAutomation {
             checkedIntune = true
             
             Logger.info("  Version \(processedAppResults.appVersionActual) is not yet uploaded to Intune", category: .automation)
+        }
+
+        // MARK: - Determine reuse target for single-app-policy mode
+        // Reuses the already-fetched appInfo array (populated by the expected- or
+        // actual-version checks above) — no extra Graph round-trip needed.
+        var existingAppId: String? = nil
+        if processedAppResults.appUseSingleAppPolicy, !appInfo.isEmpty {
+            existingAppId = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }.last?.id
+            if appInfo.count > 1 {
+                Logger.info("⚠️ Single-policy mode: uploading against the most recent of \(appInfo.count) existing records (id: \(existingAppId ?? "?")). Use the GUI's consolidate action to trim duplicates.", category: .automation)
+            }
         }
 
         // MARK: - Upload to Intune
@@ -374,7 +392,7 @@ extension LabelAutomation {
 
             // Call the upload function
             statusManager.updateUploadStatus(operationId, "Uploading to Microsoft Intune", progress: 0.0)
-            newAppID = try await EntraGraphRequests.uploadAppToIntune(authToken: authToken, app: processedAppResults, operationId: operationId)
+            newAppID = try await EntraGraphRequests.uploadAppToIntune(authToken: authToken, app: processedAppResults, operationId: operationId, existingAppId: existingAppId)
             statusManager.updateUploadStatus(operationId, "Upload completed", progress: 1.0)
             Logger.info("New app ID post upload: \(newAppID)", category: .automation)
             
@@ -460,45 +478,50 @@ extension LabelAutomation {
         }
 
         // ...continue with unassigning/removing old versions
-        // Unassign old versions
-        do {
-            
-            for app in appInfo {
-                Logger.info("App: \(app.displayName)", category: .automation)
-                Logger.info("Version: \(app.primaryBundleVersion)", category: .automation)
-                Logger.info("Tracking ID: \(app.id)", category: .automation)
-                Logger.info("Creation Date: \(app.createdDateTime)", category: .automation)
+        // Skipped entirely in single-app-policy mode — the same record was patched in place,
+        // and uploadAppToIntune's assignGroupsToApp call already reasserted the correct
+        // assignment set on that single record, so there is nothing to unassign or delete.
+        if !processedAppResults.appUseSingleAppPolicy {
+            // Unassign old versions
+            do {
 
-                if app.primaryBundleVersion != processedAppResults.appVersionActual {
-                    if app.isAssigned == true {
-                        Logger.info("Older assigned version found in Intune!", category: .automation)
-                        Logger.info("Unassigning older version for app \(app.displayName)", category: .automation)
-                        Logger.info("Unassigning older version for app \(app.primaryBundleVersion)", category: .automation)
-                        Logger.info("Unassigning older version for app \(app.id)", category: .automation)
+                for app in appInfo {
+                    Logger.info("App: \(app.displayName)", category: .automation)
+                    Logger.info("Version: \(app.primaryBundleVersion)", category: .automation)
+                    Logger.info("Tracking ID: \(app.id)", category: .automation)
+                    Logger.info("Creation Date: \(app.createdDateTime)", category: .automation)
 
-                        try await EntraGraphRequests.removeAllAppAssignments(authToken: authToken, appId: app.id)
+                    if app.primaryBundleVersion != processedAppResults.appVersionActual {
+                        if app.isAssigned == true {
+                            Logger.info("Older assigned version found in Intune!", category: .automation)
+                            Logger.info("Unassigning older version for app \(app.displayName)", category: .automation)
+                            Logger.info("Unassigning older version for app \(app.primaryBundleVersion)", category: .automation)
+                            Logger.info("Unassigning older version for app \(app.id)", category: .automation)
+
+                            try await EntraGraphRequests.removeAllAppAssignments(authToken: authToken, appId: app.id)
+                        }
                     }
                 }
-            }
-            
-            // Clean up extra older versions of the app
-            let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
-            let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
-            let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
-            if versionsToDeleteCount > 0 {
-                let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
-                for app in appsToDelete {
-                    guard !app.isAssigned else { continue }
-                    Logger.info("Deleting older app \(app.displayName)", category: .automation)
-                    Logger.info("Deleting older app \(app.primaryBundleVersion)", category: .automation)
-                    Logger.info("Deleting older app \(app.id)", category: .automation)
-                    try await EntraGraphRequests.deleteIntuneApp(authToken: authToken, appId: app.id)
+
+                // Clean up extra older versions of the app
+                let appVersionsToKeep = ConfigManager.readPlistValue(key: "AppVersionsToKeep") ?? 2
+                let sortedAppInfo = appInfo.sorted { $0.createdDateTime < $1.createdDateTime }
+                let versionsToDeleteCount = max(0, sortedAppInfo.count - appVersionsToKeep)
+                if versionsToDeleteCount > 0 {
+                    let appsToDelete = sortedAppInfo.prefix(versionsToDeleteCount)
+                    for app in appsToDelete {
+                        guard !app.isAssigned else { continue }
+                        Logger.info("Deleting older app \(app.displayName)", category: .automation)
+                        Logger.info("Deleting older app \(app.primaryBundleVersion)", category: .automation)
+                        Logger.info("Deleting older app \(app.id)", category: .automation)
+                        try await EntraGraphRequests.deleteIntuneApp(authToken: authToken, appId: app.id)
+                    }
                 }
+
+            } catch {
+                Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
+                return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) uploaded. Failed to delete older apps from Intune: \(error.localizedDescription)", "\(processedAppResults.appIntuneDisplayName)", newAppID, true)
             }
-            
-        } catch {
-            Logger.error("Failed to delete older apps from Intune: \(error.localizedDescription)", category: .automation)
-            return ("\(processedAppResults.appIntuneDisplayName) \(processedAppResults.appVersionActual) uploaded. Failed to delete older apps from Intune: \(error.localizedDescription)", "\(processedAppResults.appIntuneDisplayName)", newAppID, true)
         }
 
         

--- a/IntuneomatorService/Utilities/MetadataLoader.swift
+++ b/IntuneomatorService/Utilities/MetadataLoader.swift
@@ -53,6 +53,7 @@ struct MetadataLoader {
         let ignoreVersion = metadata?.ignoreVersionDetection ?? false
         let informationURL = metadata?.informationUrl ?? ""
         let managed = metadata?.isManaged ?? false
+        let singleAppPolicy = metadata?.useSingleAppPolicy ?? false
         let notes = metadata?.notes ?? ""
         let owner = metadata?.owner ?? ""
         let minimumOS = metadata?.minimumOS
@@ -218,6 +219,7 @@ struct MetadataLoader {
             appIsDualArchCapable: isDualArch,
             appIsFeatured: featured,
             appIsManaged: managed,
+            appUseSingleAppPolicy: singleAppPolicy,
             appLabelName: labelName,
             appLabelType: validatedType,
             appLocalURL: "",

--- a/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
+++ b/IntuneomatorService/XPCService/XPCService+ViewCalls.swift
@@ -217,6 +217,26 @@ extension XPCService {
         }
     }
 
+    /// Consolidates all existing Intune app records for a label folder's tracking ID down to
+    /// a single survivor (newest by createdDateTime), deleting the rest and reasserting the
+    /// current local group assignments on the survivor. Destructive — the caller must have
+    /// already obtained user confirmation before invoking this.
+    /// - Parameters:
+    ///   - labelFolder: Target label folder name (format "label_GUID")
+    ///   - reply: Callback with a result dictionary containing "survivorAppId" (String?),
+    ///     "deletedCount" (Int), "success" (Bool), and "message" (String)
+    func consolidateToSingleAppPolicy(_ labelFolder: String, reply: @escaping ([String: Any]?) -> Void) {
+        Task {
+            let result = await LabelAutomation.consolidateToSingleAppPolicy(named: labelFolder)
+            reply([
+                "survivorAppId": result.survivorAppId as Any,
+                "deletedCount": result.deletedCount,
+                "success": result.success,
+                "message": result.message
+            ])
+        }
+    }
+
     // MARK: - Label Content Management
 
     /// Creates a new managed label folder with initial content and metadata

--- a/SharedCode/XPCServiceProtocol.swift
+++ b/SharedCode/XPCServiceProtocol.swift
@@ -112,6 +112,16 @@ import Foundation
     ///   - reply: Callback with array of application dictionaries or nil on failure
     func findAppsByTrackingID(trackingID: String, reply: @escaping ([[String: Any]]?) -> Void)
 
+    /// Consolidates all existing Intune app records for a label folder's tracking ID down to
+    /// a single survivor (newest by createdDateTime), deleting the rest and reasserting the
+    /// current local group assignments on the survivor. Destructive — the caller must have
+    /// already obtained user confirmation before invoking this.
+    /// - Parameters:
+    ///   - labelFolder: Target label folder name (format "label_GUID")
+    ///   - reply: Callback with a result dictionary containing "survivorAppId" (String?),
+    ///     "deletedCount" (Int), "success" (Bool), and "message" (String)
+    func consolidateToSingleAppPolicy(_ labelFolder: String, reply: @escaping ([String: Any]?) -> Void)
+
     // MARK: - Installomator Label Management
     
     /// Adds new label content from a source (GitHub or custom)


### PR DESCRIPTION
Add new mode that uploads new versions to the same app policy when selected in the GUI automation for useSingleAppPolicy. Instead of creating new app policies for every new version, the same policy gets updated in place.

Microsoft's current guidance for updating LOB has admins updating in place. https://learn.microsoft.com/en-us/intune/app-management/deployment/add-lob-macos#update-a-line-of-business-app